### PR TITLE
Fix GetEntityHeading argument

### DIFF
--- a/car_spawn/client/client.lua
+++ b/car_spawn/client/client.lua
@@ -4,7 +4,7 @@ RegisterCommand('auto', function(source, args)
     local vehicle = args[1] -- Zmienna odpowiadająca za wczytanie do zmiennej naszego argumentu[1]
     local ped = PlayerPedId() -- Wczytujemy, że my to my czyli postać PED
     local pos = GetEntityCoords(ped) -- Wczytujemy coords naszej postaci PED
-    local posheading = GetEntityHeading(pos)
+    local posheading = GetEntityHeading(ped)
 
     RequestModel(vehicle) -- Request gry o podany w args[1] model samochodu
 
@@ -36,7 +36,7 @@ function carspawn(car)
     local vehicle = car -- Zmienna odpowiadająca za wczytanie do zmiennej naszego argumentu[1]
     local ped = PlayerPedId() -- Wczytujemy, że my to my czyli postać PED
     local pos = GetEntityCoords(ped) -- Wczytujemy coords naszej postaci PED
-    local posheading = GetEntityHeading(pos)
+    local posheading = GetEntityHeading(ped)
 
     RequestModel(vehicle) -- Request gry o podany w args[1] model samochodu
 

--- a/car_spawn_with_dv/client/client.lua
+++ b/car_spawn_with_dv/client/client.lua
@@ -2,7 +2,7 @@
 function spawn(vehicle)
     local ped = PlayerPedId()                                                                 -- Wczytujemy, że my to my czyli postać PED
     local pos = GetEntityCoords(ped)                                                          -- Wczytujemy coords naszej postaci PED
-    local posheading = GetEntityHeading(pos)
+    local posheading = GetEntityHeading(ped)
     RequestModel(vehicle)                                                                     -- Request gry o podany w args[1] model samochodu
 
     while not HasModelLoaded(vehicle) do


### PR DESCRIPTION
## Summary
- fix incorrect argument to `GetEntityHeading` in client vehicle spawn scripts

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68420e3ea1a88325ae79164d6e6c391e