### PR TITLE
Fix extra ped duplication

### DIFF
--- a/pappu-multicharacter/client/main.lua
+++ b/pappu-multicharacter/client/main.lua
@@ -1,5 +1,11 @@
 local cam = nil
 local charPed = nil
+local extraPed = nil
+-- Used to cancel old preview spawn threads
+local spawnIdx = 0
+local activeChar = nil
+local extraChar = nil
+local arrowActive = false
 local loadScreenCheckState = false
 local QBCore = exports['qb-core']:GetCoreObject()
 local cached_player_skins = {}
@@ -46,21 +52,131 @@ local function loadModel(model)
     end
 end
 
+local function safeDelete(entity)
+    if not DoesEntityExist(entity) then return end
 
-local function initializePedModel(model, data)
-    CreateThread(function()
-        if not model then
-            model = joaat(randommodels[math.random(#randommodels)])
+    NetworkRequestControlOfEntity(entity)
+    local attempts = 0
+    while not NetworkHasControlOfEntity(entity) and attempts < 50 do
+        Wait(0)
+        NetworkRequestControlOfEntity(entity)
+        attempts = attempts + 1
+    end
+
+    SetEntityAsMissionEntity(entity, false, true)
+    DeleteEntity(entity)
+end
+
+
+local function spawnPreviewPed(cData, coords, isExtra)
+    local model
+    local data
+    if cData then
+        if not cached_player_skins[cData.citizenid] then
+            local temp_model = promise.new()
+            local temp_data = promise.new()
+            QBCore.Functions.TriggerCallback('pappu-multicharacter:server:getSkin', function(m, d)
+                temp_model:resolve(m)
+                temp_data:resolve(d)
+            end, cData.citizenid)
+            model = Citizen.Await(temp_model)
+            data = Citizen.Await(temp_data)
+            cached_player_skins[cData.citizenid] = {model = model, data = data}
+        else
+            model = cached_player_skins[cData.citizenid].model
+            data = cached_player_skins[cData.citizenid].data
         end
-        loadModel(model)
-        charPed = CreatePed(2, model, Config.PedCoords.x, Config.PedCoords.y, Config.PedCoords.z - 0.98, Config.PedCoords.w, false, true)
-        SetPedComponentVariation(charPed, 0, 0, 0, 2)
-        FreezeEntityPosition(charPed, false)
-        SetEntityInvincible(charPed, true)
-        PlaceObjectOnGroundProperly(charPed)
-        SetBlockingOfNonTemporaryEvents(charPed, true)
-        if data then
-            TriggerEvent('qb-clothing:client:loadPlayerClothing', data, charPed)
+    end
+
+    model = model ~= nil and tonumber(model) or joaat(randommodels[math.random(#randommodels)])
+    loadModel(model)
+    local ped = CreatePed(2, model, coords.x, coords.y, coords.z - 0.98, coords.w, false, true)
+    SetPedComponentVariation(ped, 0, 0, 0, 2)
+    FreezeEntityPosition(ped, false)
+    SetEntityInvincible(ped, true)
+    PlaceObjectOnGroundProperly(ped)
+    SetBlockingOfNonTemporaryEvents(ped, true)
+    if data then
+        data = json.decode(data)
+        TriggerEvent('qb-clothing:client:loadPlayerClothing', data, ped)
+    end
+    if isExtra then
+        local RandomAnimins = {
+            "WORLD_HUMAN_HANG_OUT_STREET",
+            "WORLD_HUMAN_STAND_IMPATIENT",
+            "WORLD_HUMAN_STAND_MOBILE",
+            "WORLD_HUMAN_SMOKING_POT",
+            "WORLD_HUMAN_LEANING",
+            "WORLD_HUMAN_DRUG_DEALER_HARD",
+            "WORLD_HUMAN_MUSCLE_FLEX",
+            "WORLD_HUMAN_STAND_MOBILE_UPRIGHT",
+            "WORLD_HUMAN_CLIPBOARD",
+            "WORLD_HUMAN_AA_SMOKE",
+            "WORLD_HUMAN_DRINKING",
+            "WORLD_HUMAN_CHEERING",
+            "WORLD_HUMAN_HUMAN_STATUE",
+            "WORLD_HUMAN_STUPOR",
+            "WORLD_HUMAN_TOURIST_MOBILE",
+            "WORLD_HUMAN_JOG_STANDING",
+            "WORLD_HUMAN_PUSH_UPS",
+            "WORLD_HUMAN_SIT_UPS",
+            "WORLD_HUMAN_YOGA",
+            "WORLD_HUMAN_PROSTITUTE_HIGH_CLASS",
+            "WORLD_HUMAN_PROSTITUTE_LOW_CLASS",
+            "WORLD_HUMAN_CAR_PARK_ATTENDANT",
+            "WORLD_HUMAN_GUARD_STAND",
+            "WORLD_HUMAN_BINOCULARS",
+            "WORLD_HUMAN_PAPARAZZI"
+        }
+        local PlayAnimin = RandomAnimins[math.random(#RandomAnimins)]
+        SetPedCanPlayAmbientAnims(ped, true)
+        TaskStartScenarioInPlace(ped, PlayAnimin, 0, true)
+        -- extra ped performs ambient scenario
+    else
+        -- main ped idle
+    end
+    return ped
+end
+
+local function spawnPreviewPeds(characters)
+    spawnIdx = spawnIdx + 1
+    local myIdx = spawnIdx
+    CreateThread(function()
+        local oldChar = charPed
+        local oldExtra = extraPed
+        safeDelete(oldChar)
+        safeDelete(oldExtra)
+        charPed = nil
+        extraPed = nil
+        activeChar = characters[1]
+        extraChar = characters[2]
+        local myChar = spawnPreviewPed(activeChar, Config.PedCoords, false)
+        if myIdx ~= spawnIdx then
+            safeDelete(myChar)
+            return
+        end
+        charPed = myChar
+        local myExtra
+        if extraChar then
+            myExtra = spawnPreviewPed(extraChar, Config.SecondPedCoords, true)
+            if myIdx ~= spawnIdx then
+                safeDelete(myChar)
+                safeDelete(myExtra)
+                return
+            end
+            extraPed = myExtra
+        end
+        if not arrowActive then
+            arrowActive = true
+            CreateThread(function()
+                while arrowActive do
+                    if charPed and DoesEntityExist(charPed) then
+                        local c = GetEntityCoords(charPed)
+                        DrawMarker(2, c.x, c.y, c.z + 1.2, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.4, 0.4, 0.4, 148, 0, 211, 200, false, true, 2, false, nil, nil, false)
+                    end
+                    Wait(0)
+                end
+            end)
         end
     end)
 end
@@ -113,7 +229,11 @@ end
 
 RegisterNetEvent('pappu-multicharacter:client:closeNUIdefault', function() -- This event is only for no starting apartments
     if not IsScreenFadedOut() then DoScreenFadeOut(500) end
-    DeleteEntity(charPed)
+    safeDelete(charPed)
+    charPed = nil
+    safeDelete(extraPed)
+    extraPed = nil
+    arrowActive = false
     SetNuiFocus(false, false)
     DoScreenFadeOut(500)
     Wait(2000)
@@ -142,7 +262,11 @@ RegisterNetEvent('pappu-multicharacter:client:closeNUIdefault', function() -- Th
 end)
 
 RegisterNetEvent('pappu-multicharacter:client:closeNUI', function()
-    DeleteEntity(charPed)
+    safeDelete(charPed)
+    charPed = nil
+    safeDelete(extraPed)
+    extraPed = nil
+    arrowActive = false
     SetNuiFocus(false, false)
 end)
 
@@ -206,13 +330,17 @@ end)
 
 -- NUI Callbacks
 
-RegisterNUICallback('closeUI', function(_, cb)
+RegisterNUICallback('closeUI', function(data, cb)
     local cData = data.cData
     DoScreenFadeOut(10)
     TriggerServerEvent('pappu-multicharacter:server:loadUserData', cData)
     openCharMenu(false)
     SetEntityAsMissionEntity(charPed, true, true)
-    DeleteEntity(charPed)
+    safeDelete(charPed)
+    charPed = nil
+    safeDelete(extraPed)
+    extraPed = nil
+    arrowActive = false
     if Config.SkipSelection then
         SetNuiFocus(false, false)
         skyCam(false)
@@ -224,32 +352,11 @@ end)
 
 RegisterNUICallback('disconnectButton', function(_, cb)
     SetEntityAsMissionEntity(charPed, true, true)
-    DeleteEntity(charPed)
-    TriggerServerEvent('pappu-multicharacter:server:disconnect')
-    cb("ok")
-end)
-
--- NUI Callbacks
-
-RegisterNUICallback('closeUI', function(_, cb)
-    local cData = data.cData
-    DoScreenFadeOut(10)
-    TriggerServerEvent('pappu-multicharacter:server:loadUserData', cData)
-    openCharMenu(false)
-    SetEntityAsMissionEntity(charPed, true, true)
-    DeleteEntity(charPed)
-    if Config.SkipSelection then
-        SetNuiFocus(false, false)
-        skyCam(false)
-    else
-        openCharMenu(false)
-    end
-    cb("ok")
-end)
-
-RegisterNUICallback('disconnectButton', function(_, cb)
-    SetEntityAsMissionEntity(charPed, true, true)
-    DeleteEntity(charPed)
+    safeDelete(charPed)
+    charPed = nil
+    safeDelete(extraPed)
+    extraPed = nil
+    arrowActive = false
     TriggerServerEvent('pappu-multicharacter:server:disconnect')
     cb("ok")
 end)
@@ -260,88 +367,21 @@ RegisterNUICallback('selectCharacter', function(data, cb)
     TriggerServerEvent('pappu-multicharacter:server:loadUserData', cData)
     openCharMenu(false)
     SetEntityAsMissionEntity(charPed, true, true)
-    DeleteEntity(charPed)
+    safeDelete(charPed)
+    charPed = nil
+    safeDelete(extraPed)
+    extraPed = nil
+    arrowActive = false
     cb("ok")
 end)
 
 RegisterNUICallback('cDataPed', function(nData, cb)
     local cData = nData.cData
-    SetEntityAsMissionEntity(charPed, true, true)
-    DeleteEntity(charPed)
-    if cData ~= nil then
-        if not cached_player_skins[cData.citizenid] then
-            local temp_model = promise.new()
-            local temp_data = promise.new()
-
-            QBCore.Functions.TriggerCallback('pappu-multicharacter:server:getSkin', function(model, data)
-                temp_model:resolve(model)
-                temp_data:resolve(data)
-            end, cData.citizenid)
-
-            local resolved_model = Citizen.Await(temp_model)
-            local resolved_data = Citizen.Await(temp_data)
-
-            cached_player_skins[cData.citizenid] = {model = resolved_model, data = resolved_data}
-        end
-
-        local model = cached_player_skins[cData.citizenid].model
-        local data = cached_player_skins[cData.citizenid].data
-
-        model = model ~= nil and tonumber(model) or false
-
-        if model ~= nil then
-            CreateThread(function()
-                RequestModel(model)
-                while not HasModelLoaded(model) do
-                    Wait(0)
-                end
-                charPed = CreatePed(2, model, Config.PedCoords.x, Config.PedCoords.y, Config.PedCoords.z - 0.98, Config.PedCoords.w, false, true)
-                local RandomAnimins = {
-                    "WORLD_HUMAN_HANG_OUT_STREET",
-                    "WORLD_HUMAN_STAND_IMPATIENT",
-                    "WORLD_HUMAN_STAND_MOBILE",
-                    "WORLD_HUMAN_SMOKING_POT",
-                    "WORLD_HUMAN_LEANING",
-                    "WORLD_HUMAN_DRUG_DEALER_HARD",
-                    "WORLD_HUMAN_MUSCLE_FLEX",
-                    "WORLD_HUMAN_STAND_MOBILE_UPRIGHT",
-                    "WORLD_HUMAN_CLIPBOARD",
-                    "WORLD_HUMAN_AA_SMOKE",
-                    "WORLD_HUMAN_DRINKING",
-                    "WORLD_HUMAN_CHEERING",
-                    "WORLD_HUMAN_HUMAN_STATUE",
-                    "WORLD_HUMAN_STUPOR",
-                    "WORLD_HUMAN_TOURIST_MOBILE",
-                    "WORLD_HUMAN_JOG_STANDING",
-                    "WORLD_HUMAN_PUSH_UPS",
-                    "WORLD_HUMAN_SIT_UPS",
-                    "WORLD_HUMAN_YOGA",
-                    "WORLD_HUMAN_PROSTITUTE_HIGH_CLASS",
-                    "WORLD_HUMAN_PROSTITUTE_LOW_CLASS",
-                    "WORLD_HUMAN_CAR_PARK_ATTENDANT",
-                    "WORLD_HUMAN_GUARD_STAND",
-                    "WORLD_HUMAN_BINOCULARS",
-                    "WORLD_HUMAN_PAPARAZZI"
-                }
-                local PlayAnimin = RandomAnimins[math.random(#RandomAnimins)]
-                SetPedCanPlayAmbientAnims(charPed, true)
-                TaskStartScenarioInPlace(charPed, PlayAnimin, 0, true)
-                SetPedComponentVariation(charPed, 0, 0, 0, 2)
-                FreezeEntityPosition(charPed, false)
-                SetEntityInvincible(charPed, true)
-                PlaceObjectOnGroundProperly(charPed)
-                SetBlockingOfNonTemporaryEvents(charPed, true)
-                data = json.decode(data)
-                TriggerEvent('qb-clothing:client:loadPlayerClothing', data, charPed)
-            end)
-        else
-            initializePedModel()
-        end
-        cb("ok")
-    else
-        initializePedModel()
-        cb("ok")
-    end
+    local previous = activeChar
+    activeChar = cData
+    extraChar = previous
+    spawnPreviewPeds({activeChar, extraChar})
+    cb("ok")
 end)
 
 RegisterNUICallback('setupCharacters', function(_, cb)
@@ -351,6 +391,7 @@ RegisterNUICallback('setupCharacters', function(_, cb)
             action = "setupCharacters",
             characters = result
         })
+        spawnPreviewPeds(result)
         cb("ok")
     end)
 end)

--- a/pappu-multicharacter/config.lua
+++ b/pappu-multicharacter/config.lua
@@ -2,6 +2,7 @@ Config = {}
 Config.Interior = vector3(-1004.36, -477.9, 51.63) -- Interior to load where characters are previewed
 Config.DefaultSpawn = vector3(-1004.36, -477.9, 51.63) -- Default spawn coords if you have start apartments disabled
 Config.PedCoords = vector4(-1007.326, -477.578, 50.028, 208.64) -- Create preview ped at these coordinates
+Config.SecondPedCoords = vector4(-1005.9, -476.0, 50.028, 180.0) -- Second preview ped location
 Config.HiddenCoords = vector4(-1001.11, -478.06, 50.03, 24.55) -- Hides your actual ped while you are in selection
 Config.CamCoords = vector4(-1005.53, -480.73, 50.52, 27.44) -- Camera coordinates for character preview screen
 Config.EnableDeleteButton = true -- Define if the player can delete the character or not


### PR DESCRIPTION
## Summary
- ensure ped cleanup resets state
- improve safeDelete helper to fully remove entities
- add missing newline at EOF

## Testing
- `luac -p pappu-multicharacter/client/main.lua` *(passes)*
- `luacheck pappu-multicharacter/client/main.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842124d4ae48325a31637d7b3c05683