### PR TITLE
Add microphone HUD icon

### DIFF
--- a/elixir-hud/web/index.html
+++ b/elixir-hud/web/index.html
@@ -785,7 +785,21 @@
                 </div>
                 <p class="inter500 p-black62">4</p>
               </li>
-              
+
+              <li id="mic-icon" style="display: none;">
+                <div class="container" style="background: rgba(255, 255, 255, 0.35)">
+                  <div
+                    class="icon-cont"
+                    name="mic"
+                    style="background: radial-gradient(rgba(132, 132, 132, 0), rgba(255, 255, 255, 0.5));"
+                  >
+                    <div class="value" style="background-repeat: no-repeat; background-position: center bottom; background-size: 100% 100%;">
+                      <i class="fa-solid fa-microphone" style="color: white"></i>
+                    </div>
+                  </div>
+                </div>
+              </li>
+
               <li>
                 <div
                   class="container"

--- a/elixir-hud/web/javascript.js
+++ b/elixir-hud/web/javascript.js
@@ -586,6 +586,7 @@ window.addEventListener("message", function (event) {
     }
   } else if (event.data.action == "talking") {
     if (event.data.talking) {
+      $("#mic-icon").css("display", "block");
       if (event.data.radioshit) {
         $(".icon-cont[name=radio]")
           .parent()
@@ -616,6 +617,7 @@ window.addEventListener("message", function (event) {
           );
       }
     } else {
+      $("#mic-icon").css("display", "none");
       $(".icon-cont[name=voice]")
         .parent()
         .css("background", "rgba(255, 255, 255, 0.35)");

--- a/elixir-hud/web/style.css
+++ b/elixir-hud/web/style.css
@@ -6988,3 +6988,7 @@ svg.active .svg-elem-1 {
   order: 2;
 }
 
+#mic-icon {
+  display: none;
+}
+


### PR DESCRIPTION
## Summary
- add a microphone status item in the HUD
- hide mic indicator by default in CSS
- show or hide the icon from JS when the player talks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684379f16bbc83259632e3bbcca90a44