### PR TITLE
Polish HUD localization and position tweak

### DIFF
--- a/elixir-hud/web/index.html
+++ b/elixir-hud/web/index.html
@@ -66,11 +66,11 @@
               ></path>
             </svg>
             <div class="_column_1hwi9_37">
-              <div class="_title_1hwi9_44">Settings menu</div>
-              <div class="_description_1hwi9_53">Change your settings</div>
+              <div class="_title_1hwi9_44">Menu ustawien</div>
+              <div class="_description_1hwi9_53">Zmien ustawienia</div>
             </div>
           </div>
-          <div class="_saveButton_1hwi9_61">Save</div>
+          <div class="_saveButton_1hwi9_61">Zapisz</div>
         </div>
         <div class="_divider_1hwi9_83"></div>
         <div class="_bottomContainer_1hwi9_89">
@@ -110,8 +110,8 @@
                 </svg>
               </div>
               <div class="_bottom_1hwi9_89">
-                <div class="_title_1hwi9_44">Gameplay</div>
-                <div class="_description_1hwi9_53">Settings</div>
+                <div class="_title_1hwi9_44">Rozgrywka</div>
+                <div class="_description_1hwi9_53">Ustawienia</div>
                 <div class="_line_1hwi9_169"></div>
               </div>
             </div>
@@ -151,7 +151,7 @@
               </div>
               <div class="_bottom_1hwi9_89">
                 <div class="_title_1hwi9_44">Hud</div>
-                <div class="_description_1hwi9_53">Settings</div>
+                <div class="_description_1hwi9_53">Ustawienia</div>
                 <div class="_line_1hwi9_169"></div>
               </div>
             </div>
@@ -190,8 +190,8 @@
                 </svg>
               </div>
               <div class="_bottom_1hwi9_89">
-                <div class="_title_1hwi9_44">Help Guides</div>
-                <div class="_description_1hwi9_53">Settings</div>
+                <div class="_title_1hwi9_44">Poradniki</div>
+                <div class="_description_1hwi9_53">Ustawienia</div>
                 <div class="_line_1hwi9_169"></div>
               </div>
             </div>
@@ -203,8 +203,8 @@
           >
             <div class="_option_1hwi9_191">
               <div class="_texts_1hwi9_215">
-                <div class="_title_1hwi9_44">Crosshair</div>
-                <div class="_description_1hwi9_53">Toggle the crosshair</div>
+                <div class="_title_1hwi9_44">Celownik</div>
+                <div class="_description_1hwi9_53">Przelacz celownik</div>
               </div>
 
               <div
@@ -226,9 +226,9 @@
 
             <div class="_option_1hwi9_191">
               <div class="_texts_1hwi9_215">
-                <div class="_title_1hwi9_44">Persistent Character (Wounds)</div>
+                <div class="_title_1hwi9_44">Trwale obrazenia postaci</div>
                 <div class="_description_1hwi9_53">
-                  Toggle persistent character wounds
+                  Wlacz/wylacz obrazenia postaci
                 </div>
               </div>
 
@@ -251,9 +251,9 @@
 
             <div class="_option_1hwi9_191">
               <div class="_texts_1hwi9_215">
-                <div class="_title_1hwi9_44">Golf Ball Camera</div>
+                <div class="_title_1hwi9_44">Kamera pilki golfowej</div>
                 <div class="_description_1hwi9_53">
-                  Toggle the golf ball camera
+                  Wlacz/wylacz kamere pilki golfowej
                 </div>
               </div>
 
@@ -276,9 +276,9 @@
 
             <div class="_option_1hwi9_191">
               <div class="_texts_1hwi9_215">
-                <div class="_title_1hwi9_44">Disable Large Scene Text</div>
+                <div class="_title_1hwi9_44">Wylacz duzy tekst sceny</div>
                 <div class="_description_1hwi9_53">
-                  Toggle the largems scene text
+                  Wlacz/wylacz duzy tekst sceny
                 </div>
               </div>
 
@@ -302,10 +302,10 @@
             <div class="_option_1hwi9_191">
               <div class="_texts_1hwi9_215">
                 <div class="_title_1hwi9_44">
-                  Only Show Scenes While Peeking
+                  Pokazuj sceny tylko podczas patrzenia
                 </div>
                 <div class="_description_1hwi9_53">
-                  Toggle the large scene text
+                  Wlacz/wylacz duzy tekst sceny
                 </div>
               </div>
 
@@ -328,9 +328,9 @@
 
             <div class="_option_1hwi9_191">
               <div class="_texts_1hwi9_215">
-                <div class="_title_1hwi9_44">Enable /outfits Preview</div>
+                <div class="_title_1hwi9_44">Wlacz podglad /stroje</div>
                 <div class="_description_1hwi9_53">
-                  Toggle the /outfits preview
+                  Wlacz/wylacz podglad /stroje
                 </div>
               </div>
 
@@ -353,9 +353,9 @@
 
             <div class="_option_1hwi9_191">
               <div class="_texts_1hwi9_215">
-                <div class="_title_1hwi9_44">Enable /outfits Camera</div>
+                <div class="_title_1hwi9_44">Wlacz kamere /stroje</div>
                 <div class="_description_1hwi9_53">
-                  Toggle the /outfits camera
+                  Wlacz/wylacz kamere /stroje
                 </div>
               </div>
 
@@ -378,9 +378,9 @@
 
             <div class="_option_1hwi9_191">
               <div class="_texts_1hwi9_215">
-                <div class="_title_1hwi9_44">Disable Interact Prompts</div>
+                <div class="_title_1hwi9_44">Wylacz podpowiedzi interakcji</div>
                 <div class="_description_1hwi9_53">
-                  Toggle the interact prompts
+                  Wlacz/wylacz podpowiedzi interakcji
                 </div>
               </div>
 
@@ -404,10 +404,10 @@
             <div class="_option_1hwi9_191">
               <div class="_texts_1hwi9_215">
                 <div class="_title_1hwi9_44">
-                  Enable localized weather zones
+                  Wlacz lokalne strefy pogodowe
                 </div>
                 <div class="_description_1hwi9_53">
-                  Toggle the localized weather zones
+                  Przelacz lokalne strefy pogodowe
                 </div>
               </div>
 
@@ -431,9 +431,9 @@
           <div class="_options_1hwi9_191" menuid="hud">
             <div class="_option_1hwi9_191">
               <div class="_texts_1hwi9_215">
-                <div class="_title_1hwi9_44">Select Preset (Currently: 1)</div>
+                <div class="_title_1hwi9_44">Wybierz zestaw (obecnie: 1)</div>
                 <div class="_description_1hwi9_53">
-                  Save settings for the selected preset, and then use /hud
+                  Zapisz ustawienia dla wybranego profilu, a nastepnie uzyj /hud
                   [:number]
                 </div>
               </div>
@@ -443,11 +443,11 @@
                   trink="preference"
                   type="text"
                   readonly=""
-                  placeholder="Select item..."
+                  placeholder="Wybierz opcje..."
                   value="1"
                 />
                 <div class="options">
-                  <div>Select item...</div>
+                  <div>Wybierz opcje...</div>
                   <div class="option">1</div>
                   <div class="option">2</div>
                   <div class="option">3</div>
@@ -456,8 +456,8 @@
             </div>
             <div class="_option_1hwi9_191">
               <div class="_texts_1hwi9_215">
-                <div class="_title_1hwi9_44">HUD Position</div>
-                <div class="_description_1hwi9_53">Choose HUD alignment</div>
+                <div class="_title_1hwi9_44">Pozycja HUD</div>
+                <div class="_description_1hwi9_53">Wybierz pozycje HUD</div>
               </div>
               <div class="settings-dropdown np-dropdow-active">
                 <input
@@ -466,7 +466,7 @@
                   readonly=""
                   name="hudposition"
                   trink="hudpos"
-                  placeholder="Select item..."
+                  placeholder="Wybierz opcje..."
                   value="center"
                 />
                 <div class="options">
@@ -479,8 +479,8 @@
             </div>
             <div class="_option_1hwi9_191">
               <div class="_texts_1hwi9_215">
-                <div class="_title_1hwi9_44">Show Oxygen when relevant</div>
-                <div class="_description_1hwi9_53">Toggle the oxygen bar</div>
+                <div class="_title_1hwi9_44">Pokaz tlen gdy potrzebny</div>
+                <div class="_description_1hwi9_53">Wlacz pasek tlenu</div>
               </div>
               <div
                 class="settings-switch-wrapper"
@@ -501,15 +501,15 @@
             </div>
             <!-- <div class="_option_1hwi9_191">
                        <div class="_texts_1hwi9_215">
-                          <div class="_title_1hwi9_44">Hide  Enhancements</div>
+                          <div class="_title_1hwi9_44">Ukryj ulepszenia</div>
                           <div class="_description_1hwi9_53">Toggle the enhancements</div>
                        </div>
                        <div class="settings-switch-wrapper" style="justify-content: space-between;"><input class="np-switch hideenchantments_input" id="np-switch-hud.status.buffs.disabled" name="hideenchantments" type="checkbox" checked=""><label class="np-switch-toggle enabled" for="np-switch-hud.status.buffs.disabled"><span class="np-switch-button"></span></label></div>
                     </div> -->
             <div class="_option_1hwi9_191">
               <div class="_texts_1hwi9_215">
-                <div class="_title_1hwi9_44">Minimap Enabled</div>
-                <div class="_description_1hwi9_53">Toggle the minimap</div>
+                <div class="_title_1hwi9_44">Minimapa wlaczona</div>
+                <div class="_description_1hwi9_53">Wlacz minimape</div>
               </div>
               <div
                 class="settings-switch-wrapper"
@@ -530,9 +530,9 @@
             </div>
             <div class="_option_1hwi9_191">
               <div class="_texts_1hwi9_215">
-                <div class="_title_1hwi9_44">Show Harness durability</div>
+                <div class="_title_1hwi9_44">Pokaz trwalosc uprzeszy</div>
                 <div class="_description_1hwi9_53">
-                  Toggle the harness durability
+                  Wlacz trwalosc pasow
                 </div>
               </div>
               <div
@@ -554,9 +554,9 @@
             </div>
             <div class="_option_1hwi9_191">
               <div class="_texts_1hwi9_215">
-                <div class="_title_1hwi9_44">Show Nitrous levels</div>
+                <div class="_title_1hwi9_44">Pokaz poziom nitro</div>
                 <div class="_description_1hwi9_53">
-                  Toggle the nitrous levels
+                  Wlacz poziom nitro
                 </div>
               </div>
               <div
@@ -578,8 +578,8 @@
             </div>
             <div class="_option_1hwi9_191">
               <div class="_texts_1hwi9_215">
-                <div class="_title_1hwi9_44">Show Black Bars</div>
-                <div class="_description_1hwi9_53">Toggle the black bars</div>
+                <div class="_title_1hwi9_44">Pokaz czarne pasy</div>
+                <div class="_description_1hwi9_53">Wlacz czarne pasy</div>
               </div>
               <div
                 class="settings-switch-wrapper"
@@ -598,21 +598,21 @@
             </div>
             <div class="_option_1hwi9_191">
               <div class="_texts_1hwi9_215">
-                <div class="_title_1hwi9_44">Black Bar Size</div>
+                <div class="_title_1hwi9_44">Rozmiar czarnych pasow</div>
                 <div class="_description_1hwi9_53">
-                  Percentage of screen taken - ex 5%
+                  Procent ekranu zajety - np. 5%
                 </div>
               </div>
               <div class="settings-input-container input-focused">
-                <label class="np-input-label focused">Black Bar Size</label
+                <label class="np-input-label focused">Rozmiar czarnych pasow</label
                 ><input class="black-bar-input" value="10" />
               </div>
             </div>
             <div class="_option_1hwi9_191">
               <div class="_texts_1hwi9_215">
-                <div class="_title_1hwi9_44">Speedometer FPS</div>
+                <div class="_title_1hwi9_44">FPS licznika predkosci</div>
                 <div class="_description_1hwi9_53">
-                  The higher the FPS, the more demanding this is on your machine
+                  Im wyzszy FPS, tym wieksze obciazenie komputera
                 </div>
               </div>
               <div class="settings-dropdown np-dropdow-active">
@@ -621,11 +621,11 @@
                   type="text"
                   readonly=""
                   name="speedometerFps"
-                  placeholder="Select item..."
+                  placeholder="Wybierz opcje..."
                   value="15"
                 />
                 <div class="options">
-                  <div>Select item...</div>
+                  <div>Wybierz opcje...</div>
                   <div class="option">60</div>
                   <div class="option">45</div>
                   <div class="option">30</div>
@@ -635,11 +635,11 @@
             </div>
             <div class="_option_1hwi9_191">
               <div class="_texts_1hwi9_215">
-                <div class="_title_1hwi9_44">Health Icon</div>
-                <div class="_description_1hwi9_53">Hide when more than...</div>
+                <div class="_title_1hwi9_44">Ikona zdrowia</div>
+                <div class="_description_1hwi9_53">Ukryj gdy wiecej niz...</div>
               </div>
               <div class="settings-input-container input-focused">
-                <label class="np-input-label focused">100 = Never Hide</label
+                <label class="np-input-label focused">100 = Nigdy nie ukrywaj</label
                 ><input value="95" />
               </div>
               <div
@@ -661,11 +661,11 @@
             </div>
             <div class="_option_1hwi9_191">
               <div class="_texts_1hwi9_215">
-                <div class="_title_1hwi9_44">Armor Icon</div>
-                <div class="_description_1hwi9_53">Hide when more than...</div>
+                <div class="_title_1hwi9_44">Ikona pancerza</div>
+                <div class="_description_1hwi9_53">Ukryj gdy wiecej niz...</div>
               </div>
               <div class="settings-input-container input-focused">
-                <label class="np-input-label focused">100 = Never Hide</label
+                <label class="np-input-label focused">100 = Nigdy nie ukrywaj</label
                 ><input value="95" />
               </div>
               <div
@@ -687,11 +687,11 @@
             </div>
             <div class="_option_1hwi9_191">
               <div class="_texts_1hwi9_215">
-                <div class="_title_1hwi9_44">Food Icon</div>
-                <div class="_description_1hwi9_53">Hide when more than...</div>
+                <div class="_title_1hwi9_44">Ikona jedzenia</div>
+                <div class="_description_1hwi9_53">Ukryj gdy wiecej niz...</div>
               </div>
               <div class="settings-input-container input-focused">
-                <label class="np-input-label focused">100 = Never Hide</label
+                <label class="np-input-label focused">100 = Nigdy nie ukrywaj</label
                 ><input value="95" />
               </div>
               <div
@@ -713,11 +713,11 @@
             </div>
             <div class="_option_1hwi9_191">
               <div class="_texts_1hwi9_215">
-                <div class="_title_1hwi9_44">Water Icon</div>
-                <div class="_description_1hwi9_53">Hide when more than...</div>
+                <div class="_title_1hwi9_44">Ikona wody</div>
+                <div class="_description_1hwi9_53">Ukryj gdy wiecej niz...</div>
               </div>
               <div class="settings-input-container input-focused">
-                <label class="np-input-label focused">100 = Never Hide</label
+                <label class="np-input-label focused">100 = Nigdy nie ukrywaj</label
                 ><input value="95" />
               </div>
               <div
@@ -742,14 +742,14 @@
             <div class="_option_1hwi9_191">
               <div class="_texts_1hwi9_215">
                 <div class="_title_1hwi9_44">
-                  Finding your Windows Communication Device
+                  Znajdowanie urzadzenia komunikacyjnego Windows
                 </div>
                 <div class="_description_1hwi9_53">Elixir FW</div>
               </div>
             </div>
             <div class="_option_1hwi9_191">
               <div class="_texts_1hwi9_215">
-                <div class="_title_1hwi9_44">FPS Capping for UI lag:</div>
+                <div class="_title_1hwi9_44">Ograniczenie FPS interfejsu:</div>
                 <div class="_description_1hwi9_53">Elixir FW</div>
               </div>
             </div>
@@ -1575,9 +1575,7 @@
           class="absolute top-0 h-screen w-screen"
           style="display: none"
         >
-          <div class="absolute bottom-[3rem] left-[19rem]">
-          <div class="absolute bottom-[3rem] right-[3rem]">
-            <div class="relative flex h-[7rem]">
+          <div class="absolute bottom-[8rem] left-[16rem]">
               <div
                 class="font-speedo flex w-[9rem] flex-col justify-start gap-4 text-white"
               >
@@ -1692,7 +1690,7 @@
                 }
               </style>
               
-              <div class="absolute left-[9.5rem] top-[-1.15rem] flex h-[6.15rem] gap-1">
+              <div class="absolute left-[0rem] top-[4rem] flex h-[6.15rem] gap-1">
                 <div class="icon-outline flex w-[0.75rem] flex-col gap-2 from-neutral-800/30 to-white text-white">
                   <i id="vehicleIcon1" class="fa-solid fa-bolt hud-icon"></i>
                   <i id="vehicleIcon2" class="fa-solid fa-gas-pump hud-icon"></i>
@@ -1733,7 +1731,7 @@
                   </div>
                 </div>
               </div>
-              <div class="absolute left-[0.5rem] top-[-1.5rem] flex gap-2 items-center">
+              <div class="absolute left-[0.5rem] top-[-2rem] flex gap-2 items-center">
                   <div class="relative flex flex-row items-center" id="seatbelt">
                       <i class="fa-solid fa-seatbelt text-orange-500 hud-icon"></i>
                   </div>

--- a/elixir-hud/web/javascript.js
+++ b/elixir-hud/web/javascript.js
@@ -401,14 +401,14 @@ function rpmUpdate(rpm) {
       $(this)
         .addClass("ring-mediumspringgreen bg-mediumspringgreen")
         .removeClass("bg-neutral-600 ring-neutral-600");
-      if (index <= 17 && index >= 15) {
+      if (index <= 17 && index >= 14) {
         $(this).addClass("bg-red-500");
       }
     } else {
       $(this)
         .addClass("bg-neutral-600 ring-neutral-600")
         .removeClass("ring-mediumspringgreen bg-mediumspringgreen");
-      if (index <= 17 && index >= 15) {
+      if (index <= 17 && index >= 14) {
         $(this).removeClass("bg-red-500");
       }
     }


### PR DESCRIPTION
## Summary
- translate HUD setting descriptions to Polish
- place car HUD elements above the minimap
- show seatbelt indicator above RPM bar
- show fuel and battery gauges below RPM bar
- color last four RPM bars red

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843902e921c8325b57b681c483130c6