### PR TITLE
Add monochrome HUD option

### DIFF
--- a/tgiann-modern-hud/html/css/main.css
+++ b/tgiann-modern-hud/html/css/main.css
@@ -25,6 +25,18 @@ body {
   --buffbg: #ffd700;
 
   --statusBG: rgba(17, 17, 17, 0.5);
+  --monochrome-color: #9400D3;
+}
+
+body.mono {
+  --health: var(--monochrome-color);
+  --armor: var(--monochrome-color);
+  --hunger: var(--monochrome-color);
+  --water: var(--monochrome-color);
+  --stamina: var(--monochrome-color);
+  --addiction: var(--monochrome-color);
+  --oxy: var(--monochrome-color);
+  --stress: var(--monochrome-color);
 }
 
 @font-face {

--- a/tgiann-modern-hud/html/css/normal.css
+++ b/tgiann-modern-hud/html/css/normal.css
@@ -57,7 +57,7 @@
   display: flex;
   background: var(--statusBG);
   border-radius: var(--boder-radius-box);
-  margin-right: 1vh;
+  margin-right: 0.4vh;
   width: 4vh;
   height: 4vh;
   justify-content: center;

--- a/tgiann-modern-hud/html/index.html
+++ b/tgiann-modern-hud/html/index.html
@@ -241,6 +241,16 @@
             </label>
           </div>
         </div>
+
+        <div class="hud-menu-content">
+          <div class="hud-menu-content-setting">
+            <div class="hud-menu-content-setting-text">Jednokolorowy HUD</div>
+            <label class="switch">
+              <input type="checkbox" id="monochrome" />
+              <span class="slider"></span>
+            </label>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/tgiann-modern-hud/html/js/main.js
+++ b/tgiann-modern-hud/html/js/main.js
@@ -263,7 +263,7 @@ window.addEventListener("message", (event) => {
     $(".kmh-number").html(event.data.speed)
   }
   else if (event.data.action == "talking") {
-    $(".microphoneMicrophone").css("color", "#fff");
+    $(".microphoneMicrophone").css("color", "#9400D3");
   }
   else if (event.data.action == "Nottalking") {
     $(".microphoneMicrophone").css("color", "rgba(255, 255, 255, 0.4)");
@@ -398,6 +398,14 @@ $(document).on("click", "#water", function (e) {
     } else {
       elem.fadeOut();
     }
+  }
+});
+
+$(document).on("click", "#monochrome", function (e) {
+  if (e.currentTarget.checked) {
+    $("body").addClass("mono");
+  } else {
+    $("body").removeClass("mono");
   }
 });
 


### PR DESCRIPTION
## Summary
- update microphone color when speaking
- add monochrome HUD toggle in menu and script
- allow enabling purple color theme
- unify microphone spacing

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684988c7e42c83258c7d0c87c95c4528