### PR TITLE
Implement HUD layout selector

### DIFF
--- a/tgiann-modern-hud/html/css/hudmune.css
+++ b/tgiann-modern-hud/html/css/hudmune.css
@@ -160,6 +160,13 @@ input:checked + .slider:before {
     font-weight: 400;
 }
 
+.hud-menu-content select {
+    background: #303030;
+    color: #fff;
+    border: 1px solid #212121;
+    padding: 4px 6px;
+}
+
 /* black bar */
 .blackbar-container {
     position: absolute;

--- a/tgiann-modern-hud/html/css/normal.css
+++ b/tgiann-modern-hud/html/css/normal.css
@@ -64,3 +64,31 @@
   align-items: center;
   position: relative;
 }
+
+body.layout1 .normalStreetNameCompass {
+  flex-direction: column;
+  align-items: flex-start;
+}
+body.layout1 .normaleMicrophoneBox {
+  order: 2;
+}
+body.layout1 #normalCompass,
+body.layout1 .normalStreetNameCompassRight {
+  order: 1;
+}
+
+body.layout3 .normalStatusHud .normalStatusBarBig {
+  width: 3vh !important;
+  transform: rotate(-90deg);
+}
+body.layout3 .normalStatusBarBig svg {
+  transform: rotate(90deg);
+}
+
+body.layout4 .normaleMicrophoneBox {
+  display: none;
+}
+body.layout4 #normalCompass {
+  width: 100%;
+  border: 1px solid rgba(128, 128, 128, 0.5);
+}

--- a/tgiann-modern-hud/html/css/square.css
+++ b/tgiann-modern-hud/html/css/square.css
@@ -108,8 +108,8 @@
 }
 
 .squareStatusBar {
-    width: 3.5vh;
-    height: 3.5vh;
+    width: 3vh;
+    height: 3vh;
 }
 
 .squareStatusBar svg {

--- a/tgiann-modern-hud/html/index.html
+++ b/tgiann-modern-hud/html/index.html
@@ -252,6 +252,19 @@
           </div>
         </div>
 
+        <div class="hud-menu-content">
+          <div class="hud-menu-content-setting">
+            <div class="hud-menu-content-setting-text">Układ HUD</div>
+            <select id="hudLayout">
+              <option value="1">Układ 1</option>
+              <option value="2">Układ 2</option>
+              <option value="3">Układ 3</option>
+              <option value="4">Układ 4</option>
+              <option value="5">Your Choice</option>
+            </select>
+          </div>
+        </div>
+
       </div>
     </div>
   </div>

--- a/tgiann-modern-hud/html/js/main.js
+++ b/tgiann-modern-hud/html/js/main.js
@@ -81,6 +81,11 @@ window.addEventListener("message", (event) => {
         $("#monochrome").prop("checked", true);
       }
 
+      let layout = window.localStorage.getItem("hudLayout") || "2";
+      $("body").addClass("layout" + layout);
+      $("#hudLayout").val(layout);
+      enableCustomLayout(layout === "5");
+
       break;
   }
   if (event.data.action == "hudmenu") {
@@ -522,6 +527,13 @@ $(document).on("click", "#switchcircle", function (e) {
   );
 });
 
+$(document).on("change", "#hudLayout", function (e) {
+  const layout = e.currentTarget.value;
+  window.localStorage.setItem("hudLayout", layout);
+  $("body").removeClass("layout1 layout2 layout3 layout4 layout5").addClass("layout" + layout);
+  enableCustomLayout(layout === "5");
+});
+
 $(document).on("click", "#blackbar", function (e) {
   blackbar = e.currentTarget.checked;
   if (blackbar) {
@@ -550,3 +562,37 @@ $(document).mousedown(function (ev) {
     $.post("https://tgiann-modern-hud/hudmenuclose");
   }
 });
+
+function makeDraggable(elem) {
+  elem.onmousedown = function (ev) {
+    ev.preventDefault();
+    const shiftX = ev.clientX - elem.getBoundingClientRect().left;
+    const shiftY = ev.clientY - elem.getBoundingClientRect().top;
+
+    function moveAt(pageX, pageY) {
+      elem.style.left = pageX - shiftX + "px";
+      elem.style.top = pageY - shiftY + "px";
+      elem.style.position = "absolute";
+    }
+
+    function onMouseMove(event) {
+      moveAt(event.pageX, event.pageY);
+    }
+
+    document.addEventListener("mousemove", onMouseMove);
+    document.onmouseup = function () {
+      document.removeEventListener("mousemove", onMouseMove);
+      document.onmouseup = null;
+    };
+  };
+  elem.ondragstart = function () {
+    return false;
+  };
+}
+
+function enableCustomLayout(enable) {
+  if (enable) {
+    makeDraggable(document.querySelector('.normalHudTop'));
+    makeDraggable(document.querySelector('.normalStatusHud'));
+  }
+}


### PR DESCRIPTION
## Summary
- add layout selector to HUD menu
- support new layout options in CSS and JS
- make HUD modules draggable in "Your Choice" layout
- tweak default square statusbar size

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6849cd050a688325b757f8c7683aa50d