### PR TITLE
Fix layout 3 HUD ordering

### DIFF
--- a/tgiann-modern-hud/html/css/normal.css
+++ b/tgiann-modern-hud/html/css/normal.css
@@ -86,8 +86,24 @@ body.layout3 .normalStatusBarBig svg {
 }
 
 body.layout3 .normalHudTop {
-  bottom: 2vh;
-  left: calc(2vh + 7vh);
+  position: absolute;
+  bottom: 6vh;
+  left: 2vh;
+}
+
+body.layout3 .normalStreetNameCompass {
+  position: static;
+  top: 0;
+  left: 0;
+  bottom: unset;
+}
+
+body.layout3 .normalStatusHudTop {
+  position: static;
+  margin-bottom: 0;
+  margin-left: 0.4vh;
+  display: flex;
+  align-items: center;
 }
 
 body.layout4 .normaleMicrophoneBox {

--- a/tgiann-modern-hud/html/index.html
+++ b/tgiann-modern-hud/html/index.html
@@ -140,24 +140,6 @@
 
     <div class="normalHud">
       <div class="normalHudTop">
-        <div class="normalStatusHudTop">
-          <div class="normalStatusBar" id="normalHungerBar">
-            <i class="fa-solid fa-pizza-slice"></i>
-            <div class="normalStatusBarBg" id="normalhunger"></div>
-          </div>
-          <div class="normalStatusBar" id="normalWaterBar">
-            <i class="fas fa-tint"></i>
-            <div class="normalStatusBarBg" id="normalwater"></div>
-          </div>
-          <div class="normalStatusBar" id="normalStaminaBar">
-            <i class="fas fa-running"></i>
-            <div class="normalStatusBarBg" id="normalstamina"></div>
-          </div>
-          <div class="normalStatusBar" id="normalOxyBar">
-            <i class="fas fa-lungs"></i>
-            <div class="normalStatusBarBg" id="normaloxy"></div>
-          </div>
-        </div>
         <div class="normalStreetNameCompass">
           <div class="normaleMicrophoneBox">
             <div class="microphoneMicrophone">
@@ -186,6 +168,24 @@
         <div class="normalStatusBar normalStatusBarBig" id="normalWaterBar">
           <i class="fas fa-shield-alt"></i>
           <div class="normalStatusBarBg" id="normalarmor"></div>
+        </div>
+        <div class="normalStatusHudTop">
+          <div class="normalStatusBar" id="normalHungerBar">
+            <i class="fa-solid fa-pizza-slice"></i>
+            <div class="normalStatusBarBg" id="normalhunger"></div>
+          </div>
+          <div class="normalStatusBar" id="normalWaterBar">
+            <i class="fas fa-tint"></i>
+            <div class="normalStatusBarBg" id="normalwater"></div>
+          </div>
+          <div class="normalStatusBar" id="normalStaminaBar">
+            <i class="fas fa-running"></i>
+            <div class="normalStatusBarBg" id="normalstamina"></div>
+          </div>
+          <div class="normalStatusBar" id="normalOxyBar">
+            <i class="fas fa-lungs"></i>
+            <div class="normalStatusBarBg" id="normaloxy"></div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- move hunger/water/sprint bars beside the armor bar
- keep microphone and compass in a line above the health bars

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6849e9719ce883259fafa6e169621dcd