### PR TITLE
Fix orientation for Setup 2 HUD bars

### DIFF
--- a/tgiann-modern-hud/html/css/main.css
+++ b/tgiann-modern-hud/html/css/main.css
@@ -108,6 +108,12 @@ body.mono {
   box-shadow: var(--box-shadow-color);
 }
 
+body.layout3 .circleStatusBar,
+body.layout3 .squareStatusBar,
+body.layout3 .normalStatusBar {
+  transform: rotate(-90deg);
+}
+
 .circleStatusBar svg,
 .squareStatusBar svg,
 .normalStatusBar svg {
@@ -116,6 +122,12 @@ body.mono {
   z-index: 1;
   transform: rotate(-90deg);
   font-size: 1.3vh;
+}
+
+body.layout3 .circleStatusBar svg,
+body.layout3 .squareStatusBar svg,
+body.layout3 .normalStatusBar svg {
+  transform: rotate(90deg);
 }
 
 .circleStatusBarBg,

--- a/tgiann-modern-hud/html/css/normal.css
+++ b/tgiann-modern-hud/html/css/normal.css
@@ -89,10 +89,10 @@ body.layout1 .normalStreetNameCompassRight {
 
 body.layout3 .normalStatusHud .normalStatusBarBig {
   width: 3vh !important;
-  transform: rotate(90deg);
+  transform: rotate(-90deg);
 }
 body.layout3 .normalStatusBarBig svg {
-  transform: rotate(-90deg);
+  transform: rotate(90deg);
 }
 
 body.layout3 .normalHudTop {


### PR DESCRIPTION
## Summary
- flip bar orientation when layout3 (Setup 2) is used
- adjust big bars in Setup 2 to match new direction

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855dcaf2e2c8325b44f88c1e330d6e4