### PR TITLE
Merge qb seatbelt into hud

### DIFF
--- a/tgiann-modern-hud/client/carhud.lua
+++ b/tgiann-modern-hud/client/carhud.lua
@@ -1,11 +1,16 @@
 local QBCore = exports['qb-core']:GetCoreObject()
 local tekerPatlak, sikiKemer, cruiseIsOn, seatbelt, vehIsMovingFwd, alarmset, engineRunning = false, false, false, false, false, false, false
-local curSpeed, prevSpeed, kemerSayi, cruiseSpeed, speedLimit = 0.0, 0.0, 0, 999.0, 80.0
+local curSpeed, prevSpeed, cruiseSpeed, speedLimit = 0.0, 0.0, 999.0, 80.0
 local prevVelocity = {x = 0.0, y = 0.0, z = 0.0}
 local compassOn = true
 local vehAcc = false
 local inVehSetState = false
 local clock = ""
+
+-- Aktualizacja stanu pasa z modułu seatbelt
+RegisterNetEvent('tgiann-hud:client:UpdateSeatbelt', function(state)
+    seatbelt = state
+end)
 local zoneNames = {
     AIRP = "Międzynarodowe Lotnisko Los Santos",
     ALAMO = "Jezioro Alamo",
@@ -463,27 +468,8 @@ local VehicleNormalMaxSpeed = false
 local lastsikiKemer = false
 
 Citizen.CreateThread(function()
-    RegisterKeyMapping('+seatbelt', 'Pojazd (Pas bezpieczeństwa)', 'keyboard', 'b')
     RegisterKeyMapping('+cruise', 'Pojazd (Tempomat)', 'keyboard', 'y')
 end)
-
-RegisterCommand("-seatbelt", function()
-    kemerSayi = 0
-end, false)
-
-RegisterCommand("+seatbelt", function()
-    if inVehicle then
-        seatbelt = not seatbelt
-        kemerSayi = kemerSayi + 1
-        if seatbelt then
-            QBCore.Functions.Notify("Pas zapięty", "success")
-            PlaySoundFrontend(-1, "Faster_Click", "RESPAWN_ONLINE_SOUNDSET", 1)
-        else
-            QBCore.Functions.Notify("Pas odpięty", "error")
-            PlaySoundFrontend(-1, "Faster_Click", "RESPAWN_ONLINE_SOUNDSET", 1)
-        end
-    end
-end, false)
 
 RegisterCommand("+cruise", function()
     if driverSeat and engineRunning then

--- a/tgiann-modern-hud/client/seatbelt.lua
+++ b/tgiann-modern-hud/client/seatbelt.lua
@@ -1,4 +1,9 @@
 local QBCore = exports['qb-core']:GetCoreObject()
+
+local Config = {
+    HarnessUses = 20 -- Ilość użyć uprzęży wyścigowej
+}
+
 local seatbeltOn = false
 local harnessOn = false
 local harnessHp = Config.HarnessUses
@@ -41,7 +46,7 @@ local function ToggleSeatbelt()
     if class == 8 or class == 13 or class == 14 then return end
     seatbeltOn = not seatbeltOn
     SeatBeltLoop()
-    TriggerEvent("seatbelt:client:ToggleSeatbelt")
+    TriggerEvent("tgiann-hud:client:UpdateSeatbelt", seatbeltOn)
     --TriggerServerEvent("InteractSound_SV:PlayWithinDistance", 5.0, seatbeltOn and "carbuckle" or "carunbuckle", 0.25)
 end
 
@@ -53,7 +58,7 @@ end
 
 local function ResetHandBrake()
     if handbrake <= 0 then return end
-    handbrake -= 1
+    handbrake = handbrake - 1
 end
 
 function SeatBeltLoop()
@@ -67,7 +72,7 @@ function SeatBeltLoop()
             if not IsPedInAnyVehicle(PlayerPedId(), false) then
                 seatbeltOn = false
                 harnessOn = false
-                TriggerEvent("seatbelt:client:ToggleSeatbelt")
+                TriggerEvent("tgiann-hud:client:UpdateSeatbelt", seatbeltOn)
                 break
             end
             if not seatbeltOn and not harnessOn then break end
@@ -120,7 +125,7 @@ RegisterNetEvent('QBCore:Client:EnteredVehicle', function()
                                 if not harnessOn then
                                     EjectFromVehicle()
                                 else
-                                    harnessHp -= 1
+                                    harnessHp = harnessHp - 1
                                     TriggerServerEvent('seatbelt:DoHarnessDamage', harnessHp, harnessData)
                                 end
                             end
@@ -130,7 +135,7 @@ RegisterNetEvent('QBCore:Client:EnteredVehicle', function()
                                     if not harnessOn then
                                         EjectFromVehicle()
                                     else
-                                        harnessHp -= 1
+                                        harnessHp = harnessHp - 1
                                         TriggerServerEvent('seatbelt:DoHarnessDamage', harnessHp, harnessData)
                                     end
                                 end
@@ -142,7 +147,7 @@ RegisterNetEvent('QBCore:Client:EnteredVehicle', function()
                                 if not harnessOn then
                                     EjectFromVehicle()
                                 else
-                                    harnessHp -= 1
+                                    harnessHp = harnessHp - 1
                                     TriggerServerEvent('seatbelt:DoHarnessDamage', harnessHp, harnessData)
                                 end
                             end
@@ -152,7 +157,7 @@ RegisterNetEvent('QBCore:Client:EnteredVehicle', function()
                                     if not harnessOn then
                                         EjectFromVehicle()
                                     else
-                                        harnessHp -= 1
+                                        harnessHp = harnessHp - 1
                                         TriggerServerEvent('seatbelt:DoHarnessDamage', harnessHp, harnessData)
                                     end
                                 end
@@ -174,7 +179,7 @@ RegisterNetEvent('QBCore:Client:EnteredVehicle', function()
             end
             frameBodyChange = newvehicleBodyHealth - currentvehicleBodyHealth
             if tick > 0 then
-                tick -= 1
+                tick = tick - 1
                 if tick == 1 then
                     lastFrameVehiclespeed = GetEntitySpeed(currentVehicle) * 3.6
                 end
@@ -264,6 +269,10 @@ RegisterNetEvent('seatbelt:client:UseHarness', function(ItemData) -- On Item Use
 end)
 
 -- Register Key
+
+Citizen.CreateThread(function()
+    RegisterKeyMapping('toggleseatbelt', 'Pojazd (Pas bezpieczeństwa)', 'keyboard', 'b')
+end)
 
 RegisterCommand('toggleseatbelt', function()
     if not IsPedInAnyVehicle(PlayerPedId(), false) or IsPauseMenuActive() then return end


### PR DESCRIPTION
## Summary
- move seatbelt functionality from `qb-smallresources` into the HUD
- remove duplicate seatbelt logic from `qb-smallresources`
- allow HUD to listen for seatbelt state changes

## Testing
- `luac -p tgiann-modern-hud/client/seatbelt.lua`
- `luac -p tgiann-modern-hud/client/carhud.lua`

------
https://chatgpt.com/codex/tasks/task_e_6855e2fac42c8325b92f04d8003921f7