### PR TITLE
Add modern inventory interface

### DIFF
--- a/inventory/html/app.js
+++ b/inventory/html/app.js
@@ -1,0 +1,38 @@
+const pocketContainer = document.getElementById('pockets');
+const itemTemplate = document.getElementById('item-template');
+const slots = document.querySelectorAll('.slot');
+
+// generate some sample pocket items
+for (let i = 0; i < 20; i++) {
+    const node = itemTemplate.content.firstElementChild.cloneNode(true);
+    node.querySelector('img').src = '';
+    node.querySelector('.label').textContent = 'Item ' + (i+1);
+    node.dataset.id = `item-${i}`;
+    addDragHandlers(node);
+    pocketContainer.appendChild(node);
+}
+
+slots.forEach(slot => {
+    slot.addEventListener('dragover', e => e.preventDefault());
+    slot.addEventListener('drop', onDrop);
+});
+
+function addDragHandlers(item) {
+    item.addEventListener('dragstart', () => {
+        item.classList.add('dragging');
+    });
+    item.addEventListener('dragend', () => {
+        item.classList.remove('dragging');
+    });
+}
+
+function onDrop(e) {
+    e.preventDefault();
+    const dragged = document.querySelector('.dragging');
+    if (dragged) {
+        e.currentTarget.appendChild(dragged);
+    }
+}
+
+pocketContainer.addEventListener('dragover', e => e.preventDefault());
+pocketContainer.addEventListener('drop', onDrop);

--- a/inventory/html/index.html
+++ b/inventory/html/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Inventory</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="inventory-container">
+        <div id="pockets" class="grid"></div>
+        <div id="equipment">
+            <div id="player-figure">
+                <div class="slot" data-slot="backpack"><span>BACKPACK</span></div>
+                <div class="slot" data-slot="bodyarmour"><span>BODY ARMOUR</span></div>
+                <div class="slot" data-slot="phone"><span>PHONE</span></div>
+                <div class="slot" data-slot="parachute"><span>PARACHUTE</span></div>
+                <div class="slot" data-slot="weapon1"><span>WEAPON 1</span></div>
+                <div class="slot" data-slot="weapon2"><span>WEAPON 2</span></div>
+                <div class="slot" data-slot="hotkey1"><span>HOTKEY 1</span></div>
+                <div class="slot" data-slot="hotkey2"><span>HOTKEY 2</span></div>
+                <div class="slot" data-slot="hotkey3"><span>HOTKEY 3</span></div>
+            </div>
+        </div>
+    </div>
+    <template id="item-template">
+        <div class="item" draggable="true" data-id="">
+            <img src="" alt="">
+            <span class="label"></span>
+        </div>
+    </template>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/inventory/html/style.css
+++ b/inventory/html/style.css
@@ -1,0 +1,71 @@
+body {
+    font-family: Arial, Helvetica, sans-serif;
+    background: rgba(0,0,0,0.6);
+    color: white;
+    margin: 0;
+    padding: 0;
+}
+
+#inventory-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2vh;
+    padding: 2vh;
+    box-sizing: border-box;
+    height: 100vh;
+}
+
+.grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
+    grid-auto-rows: 60px;
+    gap: 1vh;
+    flex: 1;
+    min-width: 250px;
+}
+
+.item, .slot {
+    border: 1px solid rgba(255,255,255,0.3);
+    background: rgba(20,20,20,0.8);
+    box-shadow: 0 0 4px rgba(0,0,0,0.7);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    text-align: center;
+    position: relative;
+    border-radius: 4px;
+}
+
+#equipment {
+    flex: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-width: 250px;
+}
+
+#player-figure {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    grid-gap: 1vh;
+}
+
+.slot span {
+    font-size: 0.75rem;
+    margin-top: 0.2rem;
+}
+
+.item.dragging {
+    opacity: 0.5;
+}
+
+.item-common { border-color: #ffffff33; }
+.item-rare { border-color: #2e8bff; }
+
+@media (max-width: 768px) {
+    #inventory-container {
+        flex-direction: column;
+        height: auto;
+    }
+}


### PR DESCRIPTION
## Summary
- add sample NUI inventory with pockets grid and human figure layout
- apply dark theme styling
- implement basic drag and drop logic

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_685870b2f19c8325bed4ddd7551309d1