### PR TITLE
Add modern NUI mockup for ox_inventory

### DIFF
--- a/ox_inventory/html/app.js
+++ b/ox_inventory/html/app.js
@@ -1,0 +1,41 @@
+const pockets = document.getElementById('pockets');
+
+// create pocket slots
+for (let i = 0; i < 20; i++) {
+    const slot = document.createElement('div');
+    slot.classList.add('slot');
+    slot.id = `pocket-${i}`;
+    enableDrag(slot);
+    pockets.appendChild(slot);
+}
+
+function enableDrag(el) {
+    el.draggable = true;
+    el.addEventListener('dragstart', e => {
+        e.dataTransfer.setData('text/plain', el.id);
+    });
+}
+
+function handleDrop(e) {
+    e.preventDefault();
+    const id = e.dataTransfer.getData('text/plain');
+    const dragged = document.getElementById(id);
+    if (dragged && e.currentTarget !== dragged) {
+        e.currentTarget.appendChild(dragged);
+    }
+}
+
+function handleDragOver(e) {
+    e.preventDefault();
+}
+
+// apply handlers to all slots
+document.querySelectorAll("#figure .slot").forEach(enableDrag);
+function bindSlots() {
+    document.querySelectorAll('.slot').forEach(slot => {
+        slot.addEventListener('dragover', handleDragOver);
+        slot.addEventListener('drop', handleDrop);
+    });
+}
+
+bindSlots();

--- a/ox_inventory/html/index.html
+++ b/ox_inventory/html/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ox Inventory - NUI</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="inventory-container">
+        <div id="pockets" class="grid"></div>
+        <div id="equipment">
+            <div id="figure">
+                <div class="slot" id="slot-backpack" data-label="BACKPACK"></div>
+                <div class="slot" id="slot-armour" data-label="BODY ARMOUR"></div>
+                <div class="slot" id="slot-phone" data-label="PHONE"></div>
+                <div class="slot" id="slot-parachute" data-label="PARACHUTE"></div>
+                <div class="slot" id="slot-weapon1" data-label="WEAPON 1"></div>
+                <div class="slot" id="slot-weapon2" data-label="WEAPON 2"></div>
+                <div class="slot" id="slot-hotkey1" data-label="HOTKEY 1"></div>
+                <div class="slot" id="slot-hotkey2" data-label="HOTKEY 2"></div>
+                <div class="slot" id="slot-hotkey3" data-label="HOTKEY 3"></div>
+            </div>
+        </div>
+    </div>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/ox_inventory/html/style.css
+++ b/ox_inventory/html/style.css
@@ -1,0 +1,80 @@
+body {
+    margin: 0;
+    padding: 0;
+    font-family: Arial, sans-serif;
+    background: rgba(0, 0, 0, 0.7);
+    color: #fff;
+}
+
+#inventory-container {
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    height: 100vh;
+    box-sizing: border-box;
+    padding: 2vh;
+    gap: 2vw;
+}
+
+.grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
+    grid-auto-rows: 60px;
+    gap: 0.5vw;
+    width: 40vw;
+    max-width: 450px;
+}
+
+.slot {
+    position: relative;
+    border: 1px solid rgba(255,255,255,0.6);
+    background: rgba(20,20,20,0.8);
+    box-shadow: 0 0 4px rgba(0,0,0,0.5);
+    border-radius: 4px;
+    width: 60px;
+    height: 60px;
+}
+
+.slot::after {
+    content: attr(data-label);
+    position: absolute;
+    bottom: -1.4em;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 0.65em;
+    white-space: nowrap;
+}
+
+#equipment {
+    position: relative;
+    width: 20vw;
+    max-width: 280px;
+}
+
+#figure {
+    position: relative;
+    width: 100%;
+    padding-top: 220%;
+    background: rgba(80,80,80,0.2);
+    border: 1px solid rgba(255,255,255,0.2);
+    border-radius: 10px;
+}
+
+/* Slot positions */
+#slot-backpack { top: 5%; left: 50%; transform: translate(-50%, 0); }
+#slot-armour   { top: 25%; left: 50%; transform: translate(-50%, 0); }
+#slot-phone    { top: 45%; left: 50%; transform: translate(-50%, 0); }
+#slot-parachute{ top: 65%; left: 50%; transform: translate(-50%, 0); }
+#slot-weapon1  { top: 20%; left: 5%;  }
+#slot-weapon2  { top: 20%; right: 5%; }
+#slot-hotkey1  { bottom: 20%; left: 5%;  }
+#slot-hotkey2  { bottom: 20%; right: 5%; }
+#slot-hotkey3  { bottom: 5%; left: 50%; transform: translate(-50%, 0); }
+
+#figure .slot {
+    position: absolute;
+}
+
+.item-common { border-color: #ffffff; }
+.item-rare   { border-color: #4aa5ff; }
+.item-epic   { border-color: #b65dff; }


### PR DESCRIPTION
## Summary
- add new `ox_inventory/html` NUI with pockets and body slot layout
- style it with dark transparent theme and slot rarity classes
- implement drag and drop logic for item slots

## Testing
- `npm install --ignore-scripts`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685873956098832592222a8d544caa56