### PR TITLE
Customize ox_inventory HUD layout

### DIFF
--- a/ox_inventory/client_toggle.lua
+++ b/ox_inventory/client_toggle.lua
@@ -13,3 +13,19 @@ RegisterNUICallback('close', function(_, cb)
     SendNUIMessage({ action = 'hideInventory' })
     cb('ok')
 end)
+
+local tabActive = false
+CreateThread(function()
+    while true do
+        Wait(0)
+        if not IsNuiFocused() then
+            if IsControlPressed(0, 37) and not tabActive then
+                tabActive = true
+                SendNUIMessage({ action = 'showHotbarOnly' })
+            elseif not IsControlPressed(0, 37) and tabActive then
+                tabActive = false
+                SendNUIMessage({ action = 'hideHotbarOnly' })
+            end
+        end
+    end
+end)

--- a/ox_inventory/html/app.js
+++ b/ox_inventory/html/app.js
@@ -63,7 +63,7 @@ document.addEventListener('DOMContentLoaded', () => {
   hotkeys = document.getElementById('hotkeys');
 
   // generate pocket item slots
-  const pocketCount = 16;
+  const pocketCount = 25;
   for (let i = 0; i < pocketCount; i++) {
     const slot = document.createElement('div');
     slot.className = 'item-slot';

--- a/ox_inventory/html/index.html
+++ b/ox_inventory/html/index.html
@@ -8,40 +8,41 @@
 </head>
 <body>
   <div id="inventory-ui" class="inventory-wrapper hidden">
-  <div class="top-bar">
-    <span id="toggle-info">F2 - Close</span>
-  </div>
-  <div class="inventory-container">
-        <div id="pockets" class="pockets" style="display:none;">
-      <h2 class="section-title">Pockets</h2>
-      <div class="pocket-grid" id="pocket-grid"></div>
+    <div class="top-bar">
+      <span id="toggle-info">F2 - Close</span>
     </div>
-    <div class="center-panel">
-      <div id="equipment" class="character-layout" style="display:none;">
-        <img src="img/character_grid.png" class="character-bg" alt="Character">
-        <div class="slot backpack" data-slot="backpack" data-item="" data-info="">
-          <div class="icon"></div>
-          <span class="label">BACKPACK</span>
+    <div class="inventory-container">
+      <div class="inventory-main">
+        <div id="pockets" class="pockets" style="display:none;">
+          <h2 class="section-title">Pockets</h2>
+          <div class="pocket-grid" id="pocket-grid"></div>
         </div>
-        <div class="slot body-armour" data-slot="body_armour" data-item="" data-info="">
-          <div class="icon"></div>
-          <span class="label">BODY ARMOUR</span>
-        </div>
-        <div class="slot phone" data-slot="phone" data-item="" data-info="">
-          <div class="icon"></div>
-          <span class="label">PHONE</span>
-        </div>
-        <div class="slot parachute" data-slot="parachute" data-item="" data-info="">
-          <div class="icon"></div>
-          <span class="label">PARACHUTE</span>
-        </div>
-        <div class="slot weapon1" data-slot="weapon1" data-item="" data-info="">
-          <div class="icon"></div>
-          <span class="label">WEAPON 1</span>
-        </div>
-        <div class="slot weapon2" data-slot="weapon2" data-item="" data-info="">
-          <div class="icon"></div>
-          <span class="label">WEAPON 2</span>
+        <div id="equipment" class="character-layout" style="display:none;">
+          <img src="img/character_grid.png" class="character-bg" alt="Character">
+          <div class="slot backpack" data-slot="backpack" data-item="" data-info="">
+            <div class="icon"></div>
+            <span class="label">BACKPACK</span>
+          </div>
+          <div class="slot body-armour" data-slot="body_armour" data-item="" data-info="">
+            <div class="icon"></div>
+            <span class="label">BODY ARMOUR</span>
+          </div>
+          <div class="slot phone" data-slot="phone" data-item="" data-info="">
+            <div class="icon"></div>
+            <span class="label">PHONE</span>
+          </div>
+          <div class="slot parachute" data-slot="parachute" data-item="" data-info="">
+            <div class="icon"></div>
+            <span class="label">PARACHUTE</span>
+          </div>
+          <div class="slot weapon1" data-slot="weapon1" data-item="" data-info="">
+            <div class="icon"></div>
+            <span class="label">WEAPON 1</span>
+          </div>
+          <div class="slot weapon2" data-slot="weapon2" data-item="" data-info="">
+            <div class="icon"></div>
+            <span class="label">WEAPON 2</span>
+          </div>
         </div>
       </div>
       <div id="hotkeys" class="hotkeys" style="display:none;">
@@ -62,7 +63,6 @@
         </div>
       </div>
     </div>
-  </div>
   </div>
 </body>
 </html>

--- a/ox_inventory/html/style.css
+++ b/ox_inventory/html/style.css
@@ -45,6 +45,14 @@ body {
   max-width: 70rem;
 }
 
+.inventory-main {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  width: 100%;
+  flex-wrap: wrap;
+}
+
 .main-sections {
   width: 100%;
   display: flex;
@@ -71,8 +79,8 @@ body {
 
 .pocket-grid {
   display: grid;
-  grid-template-columns: repeat(4, var(--slot-size));
-  grid-template-rows: repeat(4, var(--slot-size));
+  grid-template-columns: repeat(5, var(--slot-size));
+  grid-template-rows: repeat(5, var(--slot-size));
   gap: 10px;
 }
 
@@ -214,4 +222,13 @@ body {
 .hotkey-grid .slot:hover,
 .character-layout .slot:hover {
   background: rgba(255,255,255,0.2);
+}
+
+body.hotkeys-only .pockets,
+body.hotkeys-only .character-layout {
+  display: none !important;
+}
+
+body.hotkeys-only .hotkeys {
+  display: flex !important;
 }


### PR DESCRIPTION
## Summary
- redesign inventory HTML layout with pockets, equipment and hotkeys
- expand pocket grid to 5x5
- add styles for new layout and hotkeys only view
- allow holding TAB to preview only hotkeys

## Testing
- `luac` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c7df86e8c83259f6ec3377aa26d9b