### PR TITLE
Customize ox_inventory layout

### DIFF
--- a/ox_inventory-custom/init.lua
+++ b/ox_inventory-custom/init.lua
@@ -16,7 +16,7 @@ shared = {
     resource = GetCurrentResourceName(),
     framework = GetConvar('inventory:framework', 'esx'),
     playerslots = GetConvarInt('inventory:slots', 50),
-    playerweight = GetConvarInt('inventory:weight', 30000),
+    playerweight = GetConvarInt('inventory:weight', 100000),
     target = GetConvarInt('inventory:target', 0) == 1,
     police = json.decode(GetConvar('inventory:police', '["police", "sheriff"]')),
 }

--- a/ox_inventory-custom/web/src/components/inventory/InventoryControl.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/InventoryControl.tsx
@@ -7,15 +7,11 @@ import { onUse } from '../../dnd/onUse';
 import { onGive } from '../../dnd/onGive';
 import { fetchNui } from '../../utils/fetchNui';
 import { Locale } from '../../store/locale';
-import UsefulControls from './UsefulControls';
-import ServerInfos from './ServerInfos';
 
 const InventoryControl: React.FC = () => {
   const itemAmount = useAppSelector(selectItemAmount);
   const dispatch = useAppDispatch();
 
-  const [infoVisible, setInfoVisible] = useState(false);
-  const [serverVisible, setServerVisible] = useState(false);
 
   const [, use] = useDrop<DragSource, void, any>(() => ({
     accept: 'SLOT',
@@ -39,11 +35,8 @@ const InventoryControl: React.FC = () => {
 
   return (
     <>
-      <UsefulControls infoVisible={infoVisible} setInfoVisible={setInfoVisible} />
-      <ServerInfos serverVisible={serverVisible} setServerVisible={setServerVisible} />
       <div className="inventory-control">
         <div className="inventory-control-wrapper">
-          <img className="InventoryLogo" src="https://cdn.frvgs.com/assets/custom/InventoryLogo.svg" />
           <div className="inventory-control-input-WR">
             <input
               className="inventory-control-input"
@@ -69,16 +62,6 @@ const InventoryControl: React.FC = () => {
             </div>
           </button>
           <div className="inventory-control-separator"></div>
-          <button className="inventory-control-button" onClick={() => setInfoVisible(true)}>
-            <div className="inventory-control-buttonTxt">
-              {Locale.ui_info || 'Infos'}
-            </div>
-          </button>
-          <button className="inventory-control-button" onClick={() => setServerVisible(true)}>
-            <div className="inventory-control-buttonTxt">
-              {Locale.ui_info || 'Server'}
-            </div>
-          </button>
         </div>
       </div>
     </>

--- a/ox_inventory-custom/web/src/components/inventory/InventoryGrid.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/InventoryGrid.tsx
@@ -6,7 +6,7 @@ import { getTotalWeight } from '../../helpers';
 import { useAppSelector } from '../../store';
 import { useIntersection } from '../../hooks/useIntersection';
 
-const PAGE_SIZE = 30;
+const PAGE_SIZE = 24;
 
 const InventoryGrid: React.FC<{ inventory: Inventory }> = ({ inventory }) => {
   const weight = useMemo(

--- a/ox_inventory-custom/web/src/components/inventory/index.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/index.tsx
@@ -44,9 +44,9 @@ const Inventory: React.FC = () => {
     <>
       <Fade in={inventoryVisible}>
         <div className="inventory-wrapper">
-          <LeftInventory />
-          <InventoryControl />
           <RightInventory />
+          <InventoryControl />
+          <LeftInventory />
           <Tooltip />
           <InventoryContext />
         </div>

--- a/ox_inventory-custom/web/src/vars.scss
+++ b/ox_inventory-custom/web/src/vars.scss
@@ -7,11 +7,12 @@ $secondaryColorHighlight: #33343F;
 $secondaryColorLight: rgba(0, 0, 0, 0.5);
 $secondaryColorDark: rgba(12, 12, 12, 0.8);
 
-$gridCols: 5;
-$gridRows: 5;
+$gridCols: 4;
+$gridRows: 6;
+$gridRowsVisible: 3;
 $gridSize: 10.2vh;
 $gridGap: 8px;
-$containerSize: calc(#{$gridRows} * #{$gridSize + 0.22vh} + #{$gridRows} * #{$gridGap});
+$containerSize: calc(#{$gridRowsVisible} * #{$gridSize + 0.22vh} + #{$gridRowsVisible} * #{$gridGap});
 
 $mainRadius: 6px;
 $secondRadius: 5px;


### PR DESCRIPTION
## Summary
- move player inventory to right side of UI
- remove center logo and info buttons
- adjust grid layout to 4x6 with 4x3 visible
- set max player weight to 100kg

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685f284857048325a11a2c817cbeaf5a