### PR TITLE
Modify player inventory display

### DIFF
--- a/ox_inventory-custom/init.lua
+++ b/ox_inventory-custom/init.lua
@@ -15,7 +15,7 @@ end
 shared = {
     resource = GetCurrentResourceName(),
     framework = GetConvar('inventory:framework', 'esx'),
-    playerslots = GetConvarInt('inventory:slots', 50),
+    playerslots = GetConvarInt('inventory:slots', 24),
     playerweight = GetConvarInt('inventory:weight', 100000),
     target = GetConvarInt('inventory:target', 0) == 1,
     police = json.decode(GetConvar('inventory:police', '["police", "sheriff"]')),

--- a/ox_inventory-custom/web/src/components/inventory/InventorySlot.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/InventorySlot.tsx
@@ -118,6 +118,7 @@ const InventorySlot: React.ForwardRefRenderFunction<HTMLDivElement, SlotProps> =
   };
 
   const refs = useMergeRefs([connectRef, ref]);
+  const quality = (item as SlotWithItem)?.metadata?.quality as string | undefined;
 
   return (
     <div
@@ -156,20 +157,8 @@ const InventorySlot: React.ForwardRefRenderFunction<HTMLDivElement, SlotProps> =
             }
           >
             {inventoryType === 'player' && item.slot <= 5 && <div className="inventory-slot-number">{item.slot}</div>}
-            <div className="item-slot-info-wrapper">
-              <p>
-                {item.weight > 0
-                  ? item.weight >= 1000
-                    ? `${(item.weight / 1000).toLocaleString('en-us', {
-                        minimumFractionDigits: 2,
-                      })}kg `
-                    : `${item.weight.toLocaleString('en-us', {
-                        minimumFractionDigits: 0,
-                      })}g `
-                  : ''}
-              </p>
-              <span>{item.count ? item.count.toLocaleString('en-us') + `x` : ''}</span>
-            </div>
+            <span className="item-quality">{quality}</span>
+            <span className="item-count">{item.count ? item.count.toLocaleString('en-us') + `x` : ''}</span>
           </div>
           <div
             className="item-image"
@@ -218,6 +207,13 @@ const InventorySlot: React.ForwardRefRenderFunction<HTMLDivElement, SlotProps> =
             <div className="inventory-slot-label-box">
               <div className="inventory-slot-label-text">
                 {item.metadata?.label ? item.metadata.label : Items[item.name]?.label || item.name}
+              </div>
+              <div className="inventory-slot-weight">
+                {item.weight > 0
+                  ? item.weight >= 1000
+                    ? `${(item.weight / 1000).toLocaleString('en-us', { minimumFractionDigits: 2 })}kg`
+                    : `${item.weight.toLocaleString('en-us', { minimumFractionDigits: 0 })}g`
+                  : ''}
               </div>
             </div>
           </div>

--- a/ox_inventory-custom/web/src/components/inventory/RightInventory.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/RightInventory.tsx
@@ -5,7 +5,11 @@ import { selectRightInventory } from '../../store/inventory';
 const RightInventory: React.FC = () => {
   const rightInventory = useAppSelector(selectRightInventory);
 
-  return <InventoryGrid inventory={rightInventory} />;
+  return (
+    <div className="right-inventory">
+      <InventoryGrid inventory={rightInventory} />
+    </div>
+  );
 };
 
 export default RightInventory;

--- a/ox_inventory-custom/web/src/index.scss
+++ b/ox_inventory-custom/web/src/index.scss
@@ -127,6 +127,28 @@ button:active {
   gap: 20px;
 }
 
+.right-inventory {
+  position: absolute;
+  right: 2vw;
+  top: 50%;
+  transform: translateY(-50%) rotateY(-8deg);
+  border: $mainBorder;
+  padding: 5px;
+
+  .inventory-grid-container {
+    overflow-y: auto;
+  }
+
+  .inventory-grid-container::-webkit-scrollbar {
+    display: block;
+    width: 6px;
+  }
+
+  .inventory-grid-container::-webkit-scrollbar-thumb {
+    background-color: $primary;
+  }
+}
+
 .inventory-control {
   display: flex;
 
@@ -291,7 +313,8 @@ button:active {
 .item-slot-header-wrapper {
   display: flex;
   flex-direction: row;
-  justify-content: flex-end;
+  justify-content: space-between;
+  padding: 3px;
 }
 
 .item-hotslot-header-wrapper {
@@ -581,6 +604,16 @@ button:active {
 
   .inventory-wrapper {
     gap: 40px;
+  }
+
+  .right-inventory {
+    right: 4vw;
+    transform: translateY(-50%) rotateY(-8deg);
+    border: $mainBorder4K;
+
+    .inventory-grid-container::-webkit-scrollbar {
+      width: 8px;
+    }
   }
 
   .inventory-control-wrapper {

--- a/ox_inventory-custom/web/src/slots.scss
+++ b/ox_inventory-custom/web/src/slots.scss
@@ -31,13 +31,17 @@ $bg_ARMOUR: rgba(96, 125, 139, 0.3); // Blue Grey
       #22232c 60%,
       #15151a 90%);
   color: $textColor;
-  text-align: center;
   min-height: 1vh;
   border-bottom-left-radius: $secondRadius;
   border-bottom-right-radius: $secondRadius;
   border-top-color: rgba(0, 0, 0, 0.2);
   border-top-style: inset;
   border-top-width: 0.1px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 3px;
 }
 
 .inventory-slot-label-text {
@@ -70,6 +74,21 @@ $bg_ARMOUR: rgba(96, 125, 139, 0.3); // Blue Grey
   text-shadow: 1px 1px 10px rgba(0, 0, 0, 0.6);
   -webkit-box-shadow: 1px 2px 15px 2px rgba(0, 0, 0, 0.54);
   box-shadow: 1px 2px 15px 2px rgba(0, 0, 0, 0.54);
+}
+
+.item-quality {
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+
+.item-count {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: $primary;
+}
+
+.inventory-slot-weight {
+  font-size: 0.7rem;
 }
 
 @media only screen and (min-height: 2160px) {


### PR DESCRIPTION
## Summary
- limit default player slots to 24
- place right inventory in wrapper and allow scrolling
- show item quality top‑left, quantity top‑right
- display item name and weight on bottom row
- style right inventory with border and slight angle

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685f2c8d6f288325abc80d644e72d545