### PR TITLE
Swap inventory sides and add split dialog

### DIFF
--- a/ox_inventory-custom/web/src/components/inventory/InventoryContext.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/InventoryContext.tsx
@@ -1,43 +1,20 @@
 import { onUse } from '../../dnd/onUse';
 import { onGive } from '../../dnd/onGive';
-import { onDrop } from '../../dnd/onDrop';
-import { Items } from '../../store/items';
-import { fetchNui } from '../../utils/fetchNui';
 import { Locale } from '../../store/locale';
-import { isSlotWithItem } from '../../helpers';
-import { setClipboard } from '../../utils/setClipboard';
 import { useAppSelector } from '../../store';
 import React from 'react';
 import { Menu, MenuItem } from '../utils/menu/Menu';
+import SplitDialog from './SplitDialog';
 
 interface DataProps {
   action: string;
-  component?: string;
   slot?: number;
-  serial?: string;
-  id?: number;
 }
-
-interface Button {
-  label: string;
-  index: number;
-  group?: string;
-}
-
-interface Group {
-  groupName: string | null;
-  buttons: ButtonWithIndex[];
-}
-
-interface ButtonWithIndex extends Button {
-  index: number;
-}
-
-interface GroupedButtons extends Array<Group> {}
 
 const InventoryContext: React.FC = () => {
   const contextMenu = useAppSelector((state) => state.contextMenu);
   const item = contextMenu.item;
+  const [splitVisible, setSplitVisible] = React.useState(false);
 
   const handleClick = (data: DataProps) => {
     if (!item) return;
@@ -49,103 +26,21 @@ const InventoryContext: React.FC = () => {
       case 'give':
         onGive({ name: item.name, slot: item.slot });
         break;
-      case 'drop':
-        isSlotWithItem(item) && onDrop({ item: item, inventory: 'player' });
-        break;
-      case 'remove':
-        fetchNui('removeComponent', { component: data?.component, slot: data?.slot });
-        break;
-      case 'removeAmmo':
-        fetchNui('removeAmmo', item.slot);
-        break;
-      case 'copy':
-        setClipboard(data.serial || '');
-        break;
-      case 'custom':
-        fetchNui('useButton', { id: (data?.id || 0) + 1, slot: item.slot });
+      case 'split':
+        setSplitVisible(true);
         break;
     }
   };
 
-  const groupButtons = (buttons: any): GroupedButtons => {
-    return buttons.reduce((groups: Group[], button: Button, index: number) => {
-      if (button.group) {
-        const groupIndex = groups.findIndex((group) => group.groupName === button.group);
-        if (groupIndex !== -1) {
-          groups[groupIndex].buttons.push({ ...button, index });
-        } else {
-          groups.push({
-            groupName: button.group,
-            buttons: [{ ...button, index }],
-          });
-        }
-      } else {
-        groups.push({
-          groupName: null,
-          buttons: [{ ...button, index }],
-        });
-      }
-      return groups;
-    }, []);
-  };
 
   return (
     <>
       <Menu>
         <MenuItem onClick={() => handleClick({ action: 'use' })} label={Locale.ui_use || 'Use'} />
+        <MenuItem onClick={() => handleClick({ action: 'split' })} label="Split" />
         <MenuItem onClick={() => handleClick({ action: 'give' })} label={Locale.ui_give || 'Give'} />
-        <MenuItem onClick={() => handleClick({ action: 'drop' })} label={Locale.ui_drop || 'Drop'} />
-        {item && item.metadata?.ammo > 0 && (
-          <MenuItem onClick={() => handleClick({ action: 'removeAmmo' })} label={Locale.ui_remove_ammo} />
-        )}
-        {item && item.metadata?.serial && (
-          <MenuItem
-            onClick={() => handleClick({ action: 'copy', serial: item.metadata?.serial })}
-            label={Locale.ui_copy}
-          />
-        )}
-        {item && item.metadata?.components && item.metadata?.components.length > 0 && (
-          <Menu label={Locale.ui_removeattachments}>
-            {item &&
-              item.metadata?.components.map((component: string, index: number) => (
-                <MenuItem
-                  key={index}
-                  onClick={() => handleClick({ action: 'remove', component, slot: item.slot })}
-                  label={Items[component]?.label || ''}
-                />
-              ))}
-          </Menu>
-        )}
-        {((item && item.name && Items[item.name]?.buttons?.length) || 0) > 0 && (
-          <>
-            {item &&
-              item.name &&
-              groupButtons(Items[item.name]?.buttons).map((group: Group, index: number) => (
-                <React.Fragment key={index}>
-                  {group.groupName ? (
-                    <Menu label={group.groupName}>
-                      {group.buttons.map((button: Button) => (
-                        <MenuItem
-                          key={button.index}
-                          onClick={() => handleClick({ action: 'custom', id: button.index })}
-                          label={button.label}
-                        />
-                      ))}
-                    </Menu>
-                  ) : (
-                    group.buttons.map((button: Button) => (
-                      <MenuItem
-                        key={button.index}
-                        onClick={() => handleClick({ action: 'custom', id: button.index })}
-                        label={button.label}
-                      />
-                    ))
-                  )}
-                </React.Fragment>
-              ))}
-          </>
-        )}
       </Menu>
+      <SplitDialog visible={splitVisible} onClose={() => setSplitVisible(false)} item={item} />
     </>
   );
 };

--- a/ox_inventory-custom/web/src/components/inventory/InventoryGrid.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/InventoryGrid.tsx
@@ -1,10 +1,9 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useMemo } from 'react';
 import { Inventory } from '../../typings';
 import WeightBar from '../utils/WeightBar';
 import InventorySlot from './InventorySlot';
 import { getTotalWeight } from '../../helpers';
 import { useAppSelector } from '../../store';
-import { useIntersection } from '../../hooks/useIntersection';
 
 const PAGE_SIZE = 24;
 
@@ -13,16 +12,7 @@ const InventoryGrid: React.FC<{ inventory: Inventory }> = ({ inventory }) => {
     () => (inventory.maxWeight !== undefined ? Math.floor(getTotalWeight(inventory.items) * 1000) / 1000 : 0),
     [inventory.maxWeight, inventory.items]
   );
-  const [page, setPage] = useState(0);
-  const containerRef = useRef(null);
-  const { ref, entry } = useIntersection({ threshold: 0.5 });
   const isBusy = useAppSelector((state) => state.inventory.isBusy);
-
-  useEffect(() => {
-    if (entry && entry.isIntersecting) {
-      setPage((prev) => ++prev);
-    }
-  }, [entry]);
   return (
     <>
       <div className="inventory-grid-wrapper" style={{ pointerEvents: isBusy ? 'none' : 'auto' }}>
@@ -37,19 +27,16 @@ const InventoryGrid: React.FC<{ inventory: Inventory }> = ({ inventory }) => {
           </div>
           <WeightBar percent={inventory.maxWeight ? (weight / inventory.maxWeight) * 100 : 0} />
         </div>
-        <div className="inventory-grid-container" ref={containerRef}>
-          <>
-            {inventory.items.slice(0, (page + 1) * PAGE_SIZE).map((item, index) => (
-              <InventorySlot
-                key={`${inventory.type}-${inventory.id}-${item.slot}`}
-                item={item}
-                ref={index === (page + 1) * PAGE_SIZE - 1 ? ref : null}
-                inventoryType={inventory.type}
-                inventoryGroups={inventory.groups}
-                inventoryId={inventory.id}
-              />
-            ))}
-          </>
+        <div className="inventory-grid-container">
+          {inventory.items.slice(0, PAGE_SIZE).map((item) => (
+            <InventorySlot
+              key={`${inventory.type}-${inventory.id}-${item.slot}`}
+              item={item}
+              inventoryType={inventory.type}
+              inventoryGroups={inventory.groups}
+              inventoryId={inventory.id}
+            />
+          ))}
         </div>
       </div>
     </>

--- a/ox_inventory-custom/web/src/components/inventory/LeftInventory.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/LeftInventory.tsx
@@ -5,7 +5,11 @@ import { selectLeftInventory } from '../../store/inventory';
 const LeftInventory: React.FC = () => {
   const leftInventory = useAppSelector(selectLeftInventory);
 
-  return <InventoryGrid inventory={leftInventory} />;
+  return (
+    <div className="right-inventory">
+      <InventoryGrid inventory={leftInventory} />
+    </div>
+  );
 };
 
 export default LeftInventory;

--- a/ox_inventory-custom/web/src/components/inventory/RightInventory.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/RightInventory.tsx
@@ -6,7 +6,7 @@ const RightInventory: React.FC = () => {
   const rightInventory = useAppSelector(selectRightInventory);
 
   return (
-    <div className="right-inventory">
+    <div className="left-inventory">
       <InventoryGrid inventory={rightInventory} />
     </div>
   );

--- a/ox_inventory-custom/web/src/components/inventory/SplitDialog.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/SplitDialog.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import {
+  FloatingFocusManager,
+  FloatingOverlay,
+  FloatingPortal,
+  useDismiss,
+  useFloating,
+  useInteractions,
+  useTransitionStyles,
+} from '@floating-ui/react';
+import { Locale } from '../../store/locale';
+import type { SlotWithItem } from '../../typings';
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+  item: SlotWithItem | null;
+}
+
+const SplitDialog: React.FC<Props> = ({ visible, onClose, item }) => {
+  const max = item?.count ? Math.max(1, item.count - 1) : 1;
+  const [qty, setQty] = useState(1);
+  const { refs, context } = useFloating({ open: visible, onOpenChange: onClose });
+  const dismiss = useDismiss(context, { outsidePressEvent: 'mousedown' });
+  const { isMounted, styles } = useTransitionStyles(context);
+  const { getFloatingProps } = useInteractions([dismiss]);
+
+  const update = (n: number) => setQty(Math.min(max, Math.max(1, n)));
+
+  return (
+    <>
+      {isMounted && (
+        <FloatingPortal>
+          <FloatingOverlay lockScroll className="useful-controls-dialog-overlay" data-open={visible} style={styles}>
+            <FloatingFocusManager context={context}>
+              <div ref={refs.setFloating} {...getFloatingProps()} className="useful-controls-dialog" style={styles}>
+                <div className="useful-controls-dialog-WR">
+                  <div className="useful-controls-dialog-title">
+                    <p>SPLIT</p>
+                    <div className="useful-controls-dialog-close" onClick={onClose}>
+                      ×
+                    </div>
+                  </div>
+                  <div className="useful-controls-content-wrapper">
+                    <p>Item Quantity</p>
+                    <input type="number" min={1} max={max} value={qty} onChange={(e) => update(Number(e.target.value))} />
+                    <input type="range" min={1} max={max} value={qty} onChange={(e) => update(Number(e.target.value))} />
+                    <div style={{ display: 'flex', gap: '8px', justifyContent: 'center' }}>
+                      <button onClick={() => update(Math.floor(max / 2))}>1/2</button>
+                      <button onClick={() => update(Math.floor(max / 3))}>1/3</button>
+                      <button onClick={() => update(Math.floor(max / 4))}>1/4</button>
+                    </div>
+                    <div style={{ display: 'flex', gap: '8px', justifyContent: 'center' }}>
+                      <button onClick={onClose}>{Locale.ui_cancel || 'Cancel'}</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </FloatingFocusManager>
+          </FloatingOverlay>
+        </FloatingPortal>
+      )}
+    </>
+  );
+};
+
+export default SplitDialog;

--- a/ox_inventory-custom/web/src/index.scss
+++ b/ox_inventory-custom/web/src/index.scss
@@ -149,6 +149,28 @@ button:active {
   }
 }
 
+.left-inventory {
+  position: absolute;
+  left: 2vw;
+  top: 50%;
+  transform: translateY(-50%) rotateY(8deg);
+  border: $mainBorder;
+  padding: 5px;
+
+  .inventory-grid-container {
+    overflow-y: auto;
+  }
+
+  .inventory-grid-container::-webkit-scrollbar {
+    display: block;
+    width: 6px;
+  }
+
+  .inventory-grid-container::-webkit-scrollbar-thumb {
+    background-color: $primary;
+  }
+}
+
 .inventory-control {
   display: flex;
 
@@ -609,6 +631,16 @@ button:active {
   .right-inventory {
     right: 4vw;
     transform: translateY(-50%) rotateY(-8deg);
+    border: $mainBorder4K;
+
+    .inventory-grid-container::-webkit-scrollbar {
+      width: 8px;
+    }
+  }
+
+  .left-inventory {
+    left: 4vw;
+    transform: translateY(-50%) rotateY(8deg);
     border: $mainBorder4K;
 
     .inventory-grid-container::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- swap left/right inventory containers
- style inventories on both sides of the screen
- cap displayed slots to 24
- simplify inventory context menu and add split dialog

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685f30b6fc28832597d426e0fb866395