### PR TITLE
Update right inventory styling

### DIFF
--- a/ox_inventory-custom/web/src/components/inventory/RightInventory.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/RightInventory.tsx
@@ -7,6 +7,7 @@ const RightInventory: React.FC = () => {
 
   return (
     <div className="left-inventory">
+      <h2 className="pockets-title">Pockets</h2>
       <InventoryGrid inventory={rightInventory} />
     </div>
   );

--- a/ox_inventory-custom/web/src/index.scss
+++ b/ox_inventory-custom/web/src/index.scss
@@ -125,16 +125,29 @@ button:active {
   align-items: center;
   height: 100%;
   gap: 20px;
+  z-index: 9999;
+}
+
+.pockets-title {
+  color: #fff;
+  font-size: 18px;
+  font-weight: bold;
+  margin: 0 0 10px 0;
 }
 
 .right-inventory {
   position: absolute;
-  right: 2vw;
+  left: 10%;
   top: 50%;
-  transform: translateY(-50%) rotateY(-8deg);
-  border: $mainBorder;
+  transform: translateY(-50%) perspective(1000px) rotateY(10deg);
+  transform-origin: left center;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(6px);
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.4);
   padding: 5px;
-
+  
   .inventory-grid-container {
     overflow-y: auto;
   }
@@ -626,12 +639,18 @@ button:active {
 
   .inventory-wrapper {
     gap: 40px;
+    z-index: 9999;
   }
 
   .right-inventory {
-    right: 4vw;
-    transform: translateY(-50%) rotateY(-8deg);
-    border: $mainBorder4K;
+    left: 10%;
+    transform: translateY(-50%) perspective(1000px) rotateY(10deg);
+    transform-origin: left center;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.3);
+    backdrop-filter: blur(6px);
+    box-shadow: 0 0 20px rgba(0, 0, 0, 0.4);
 
     .inventory-grid-container::-webkit-scrollbar {
       width: 8px;


### PR DESCRIPTION
## Summary
- adjust right inventory layout for modern translucent look
- style pocket title and add z-index for inventory

## Testing
- `npm run format`
- `npm run build` *(fails without dependencies)*
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685f349eebb483258d048b8356ca02ba