### PR TITLE
Update right inventory styling

### DIFF
--- a/ox_inventory-custom/web/src/components/inventory/LeftInventory.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/LeftInventory.tsx
@@ -6,7 +6,7 @@ const LeftInventory: React.FC = () => {
   const leftInventory = useAppSelector(selectLeftInventory);
 
   return (
-    <div className="right-inventory">
+    <div className="left-inventory">
       <InventoryGrid inventory={leftInventory} />
     </div>
   );

--- a/ox_inventory-custom/web/src/components/inventory/RightInventory.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/RightInventory.tsx
@@ -6,7 +6,8 @@ const RightInventory: React.FC = () => {
   const rightInventory = useAppSelector(selectRightInventory);
 
   return (
-    <div className="left-inventory">
+    <div className="right-inventory">
+      <h2 className="pockets-title">Pockets</h2>
       <InventoryGrid inventory={rightInventory} />
     </div>
   );

--- a/ox_inventory-custom/web/src/index.scss
+++ b/ox_inventory-custom/web/src/index.scss
@@ -125,16 +125,29 @@ button:active {
   align-items: center;
   height: 100%;
   gap: 20px;
+  z-index: 9999;
+}
+
+.pockets-title {
+  color: #fff;
+  font-size: 18px;
+  font-weight: bold;
+  margin: 0 0 10px 0;
 }
 
 .right-inventory {
   position: absolute;
-  right: 2vw;
+  left: 4%;
   top: 50%;
-  transform: translateY(-50%) rotateY(-8deg);
-  border: $mainBorder;
+  transform: translateY(-50%) perspective(1000px) rotateY(10deg);
+  transform-origin: left center;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(6px);
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.4);
   padding: 5px;
-
+  
   .inventory-grid-container {
     overflow-y: auto;
   }
@@ -151,10 +164,15 @@ button:active {
 
 .left-inventory {
   position: absolute;
-  left: 2vw;
+  right: 10%;
   top: 50%;
-  transform: translateY(-50%) rotateY(8deg);
-  border: $mainBorder;
+  transform: translateY(-50%) perspective(1000px) rotateY(-10deg);
+  transform-origin: right center;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(6px);
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.4);
   padding: 5px;
 
   .inventory-grid-container {
@@ -626,12 +644,18 @@ button:active {
 
   .inventory-wrapper {
     gap: 40px;
+    z-index: 9999;
   }
 
   .right-inventory {
-    right: 4vw;
-    transform: translateY(-50%) rotateY(-8deg);
-    border: $mainBorder4K;
+    left: 4%;
+    transform: translateY(-50%) perspective(1000px) rotateY(10deg);
+    transform-origin: left center;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.3);
+    backdrop-filter: blur(6px);
+    box-shadow: 0 0 20px rgba(0, 0, 0, 0.4);
 
     .inventory-grid-container::-webkit-scrollbar {
       width: 8px;
@@ -639,9 +663,14 @@ button:active {
   }
 
   .left-inventory {
-    left: 4vw;
-    transform: translateY(-50%) rotateY(8deg);
-    border: $mainBorder4K;
+    right: 10%;
+    transform: translateY(-50%) perspective(1000px) rotateY(-10deg);
+    transform-origin: right center;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.3);
+    backdrop-filter: blur(6px);
+    box-shadow: 0 0 20px rgba(0, 0, 0, 0.4);
 
     .inventory-grid-container::-webkit-scrollbar {
       width: 8px;


### PR DESCRIPTION
## Summary
- adjust inventory layouts so Pockets menu sits on the right
- apply glass effect to both inventories and tweak positions

## Testing
- `npm run format`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685f349eebb483258d048b8356ca02ba