### PR TITLE
Add equipment hotkey row

### DIFF
--- a/ox_inventory-custom/web/src/components/inventory/LeftInventory.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/LeftInventory.tsx
@@ -7,6 +7,7 @@ const LeftInventory: React.FC = () => {
 
   return (
     <div className="left-inventory">
+      <h2 className="pockets-title">Pockets</h2>
       <InventoryGrid inventory={leftInventory} />
     </div>
   );

--- a/ox_inventory-custom/web/src/components/inventory/RightInventory.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/RightInventory.tsx
@@ -1,30 +1,55 @@
 import React from 'react';
+import armourIcon from '../../../images/armour.png?url';
+import parachuteIcon from '../../../images/parachute.png?url';
+import phoneIcon from '../../../images/phone.png?url';
+import weaponIcon from '../../../images/WEAPON_PISTOL.png?url';
+import bagIcon from '../../../images/garbage.png?url';
 
 const RightInventory: React.FC = () => {
   return (
     <div className="right-inventory">
-      <h2 className="pockets-title">Pockets</h2>
+      <h2 className="pockets-title">Equipment</h2>
       <div className="equipment-grid">
         <div className="equipment-slot" style={{ gridColumn: 1, gridRow: 1 }}>
-          Backpack
+          <img src={bagIcon} alt="Backpack" className="equipment-icon" />
         </div>
         <div className="equipment-placeholder" style={{ gridColumn: 2, gridRow: '1 / span 3' }}>
           <span>PLAYER MODEL</span>
         </div>
         <div className="equipment-slot" style={{ gridColumn: 3, gridRow: 1 }}>
-          Parachute
+          <img src={parachuteIcon} alt="Parachute" className="equipment-icon" />
         </div>
         <div className="equipment-slot" style={{ gridColumn: 1, gridRow: 2 }}>
-          Body Armour
+          <img src={armourIcon} alt="Body Armour" className="equipment-icon" />
         </div>
         <div className="equipment-slot" style={{ gridColumn: 3, gridRow: 2 }}>
-          Weapon Slot 1
+          <img src={weaponIcon} alt="Weapon Slot 1" className="equipment-icon" />
         </div>
         <div className="equipment-slot" style={{ gridColumn: 1, gridRow: 3 }}>
-          Phone
+          <img src={phoneIcon} alt="Phone" className="equipment-icon" />
         </div>
         <div className="equipment-slot" style={{ gridColumn: 3, gridRow: 3 }}>
-          Weapon Slot 2
+          <img src={weaponIcon} alt="Weapon Slot 2" className="equipment-icon" />
+        </div>
+      </div>
+      <div className="hotkey-row">
+        <div className="hotkey-slot">
+          <span>HOTKEY SLOT 3</span>
+          <div className="equipment-slot">
+            <img src={weaponIcon} alt="Hotkey Slot 3" className="equipment-icon" />
+          </div>
+        </div>
+        <div className="hotkey-slot">
+          <span>HOTKEY SLOT 4</span>
+          <div className="equipment-slot">
+            <img src={weaponIcon} alt="Hotkey Slot 4" className="equipment-icon" />
+          </div>
+        </div>
+        <div className="hotkey-slot">
+          <span>HOTKEY SLOT 5</span>
+          <div className="equipment-slot">
+            <img src={weaponIcon} alt="Hotkey Slot 5" className="equipment-icon" />
+          </div>
         </div>
       </div>
     </div>

--- a/ox_inventory-custom/web/src/index.scss
+++ b/ox_inventory-custom/web/src/index.scss
@@ -193,6 +193,27 @@ button:active {
     color: rgba(255, 255, 255, 0.6);
     font-size: 0.7rem;
   }
+
+  .hotkey-row {
+    display: flex;
+    gap: 12px;
+    justify-content: center;
+    margin-top: 10px;
+  }
+
+  .hotkey-slot {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .equipment-icon {
+    width: 60px;
+    height: 60px;
+    object-fit: contain;
+    pointer-events: none;
+  }
 }
 
 .left-inventory {


### PR DESCRIPTION
## Summary
- rename left equipment title to "Equipment" and display new "Pockets" header on the right inventory
- show icons inside equipment slots
- add three hotkey slots in a centered row
- style new hotkey slots and equipment icons

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685f3c4209808325a51387de9dfcdd6e