### PR TITLE
Add equipment slot support in UI

### DIFF
--- a/ox_inventory-custom/web/src/components/inventory/RightInventory.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/RightInventory.tsx
@@ -4,51 +4,131 @@ import parachuteIcon from '../../../images/parachute.png?url';
 import phoneIcon from '../../../images/phone.png?url';
 import weaponIcon from '../../../images/WEAPON_PISTOL.png?url';
 import bagIcon from '../../../images/garbage.png?url';
+import InventorySlot from './InventorySlot';
+import { useAppSelector } from '../../store';
+import { selectLeftInventory } from '../../store/inventory';
+import { isSlotWithItem } from '../../helpers';
 
 const RightInventory: React.FC = () => {
+  const player = useAppSelector(selectLeftInventory);
+  const groups = player.groups;
+  const getItem = (slot: number) => player.items[slot - 1] || { slot };
+
   return (
     <div className="right-inventory">
       <h2 className="pockets-title">Equipment</h2>
       <div className="equipment-grid">
         <div className="equipment-slot" style={{ gridColumn: 1, gridRow: 1 }}>
-          <img src={bagIcon} alt="Backpack" className="equipment-icon" />
+          {!isSlotWithItem(getItem(6)) && (
+            <img src={bagIcon} alt="Backpack" className="equipment-icon" />
+          )}
+          <InventorySlot
+            item={getItem(6)}
+            inventoryId={player.id}
+            inventoryType={player.type}
+            inventoryGroups={groups}
+          />
         </div>
         <div className="equipment-placeholder" style={{ gridColumn: 2, gridRow: '1 / span 3' }}>
           <span>PLAYER MODEL</span>
         </div>
         <div className="equipment-slot" style={{ gridColumn: 3, gridRow: 1 }}>
-          <img src={parachuteIcon} alt="Parachute" className="equipment-icon" />
+          {!isSlotWithItem(getItem(9)) && (
+            <img src={parachuteIcon} alt="Parachute" className="equipment-icon" />
+          )}
+          <InventorySlot
+            item={getItem(9)}
+            inventoryId={player.id}
+            inventoryType={player.type}
+            inventoryGroups={groups}
+          />
         </div>
         <div className="equipment-slot" style={{ gridColumn: 1, gridRow: 2 }}>
-          <img src={armourIcon} alt="Body Armour" className="equipment-icon" />
+          {!isSlotWithItem(getItem(7)) && (
+            <img src={armourIcon} alt="Body Armour" className="equipment-icon" />
+          )}
+          <InventorySlot
+            item={getItem(7)}
+            inventoryId={player.id}
+            inventoryType={player.type}
+            inventoryGroups={groups}
+          />
         </div>
         <div className="equipment-slot" style={{ gridColumn: 3, gridRow: 2 }}>
-          <img src={weaponIcon} alt="Weapon Slot 1" className="equipment-icon" />
+          {!isSlotWithItem(getItem(1)) && (
+            <img src={weaponIcon} alt="Weapon Slot 1" className="equipment-icon" />
+          )}
+          <InventorySlot
+            item={getItem(1)}
+            inventoryId={player.id}
+            inventoryType={player.type}
+            inventoryGroups={groups}
+          />
         </div>
         <div className="equipment-slot" style={{ gridColumn: 1, gridRow: 3 }}>
-          <img src={phoneIcon} alt="Phone" className="equipment-icon" />
+          {!isSlotWithItem(getItem(8)) && (
+            <img src={phoneIcon} alt="Phone" className="equipment-icon" />
+          )}
+          <InventorySlot
+            item={getItem(8)}
+            inventoryId={player.id}
+            inventoryType={player.type}
+            inventoryGroups={groups}
+          />
         </div>
         <div className="equipment-slot" style={{ gridColumn: 3, gridRow: 3 }}>
-          <img src={weaponIcon} alt="Weapon Slot 2" className="equipment-icon" />
+          {!isSlotWithItem(getItem(2)) && (
+            <img src={weaponIcon} alt="Weapon Slot 2" className="equipment-icon" />
+          )}
+          <InventorySlot
+            item={getItem(2)}
+            inventoryId={player.id}
+            inventoryType={player.type}
+            inventoryGroups={groups}
+          />
         </div>
       </div>
       <div className="hotkey-row">
         <div className="hotkey-slot">
           <span>HOTKEY SLOT 3</span>
           <div className="equipment-slot">
-            <img src={weaponIcon} alt="Hotkey Slot 3" className="equipment-icon" />
+            {!isSlotWithItem(getItem(3)) && (
+              <img src={weaponIcon} alt="Hotkey Slot 3" className="equipment-icon" />
+            )}
+            <InventorySlot
+              item={getItem(3)}
+              inventoryId={player.id}
+              inventoryType={player.type}
+              inventoryGroups={groups}
+            />
           </div>
         </div>
         <div className="hotkey-slot">
           <span>HOTKEY SLOT 4</span>
           <div className="equipment-slot">
-            <img src={weaponIcon} alt="Hotkey Slot 4" className="equipment-icon" />
+            {!isSlotWithItem(getItem(4)) && (
+              <img src={weaponIcon} alt="Hotkey Slot 4" className="equipment-icon" />
+            )}
+            <InventorySlot
+              item={getItem(4)}
+              inventoryId={player.id}
+              inventoryType={player.type}
+              inventoryGroups={groups}
+            />
           </div>
         </div>
         <div className="hotkey-slot">
           <span>HOTKEY SLOT 5</span>
           <div className="equipment-slot">
-            <img src={weaponIcon} alt="Hotkey Slot 5" className="equipment-icon" />
+            {!isSlotWithItem(getItem(5)) && (
+              <img src={weaponIcon} alt="Hotkey Slot 5" className="equipment-icon" />
+            )}
+            <InventorySlot
+              item={getItem(5)}
+              inventoryId={player.id}
+              inventoryType={player.type}
+              inventoryGroups={groups}
+            />
           </div>
         </div>
       </div>

--- a/ox_inventory-custom/web/src/dnd/onDrop.ts
+++ b/ox_inventory-custom/web/src/dnd/onDrop.ts
@@ -5,6 +5,18 @@ import { DragSource, DropTarget, InventoryType, SlotWithItem } from '../typings'
 import { moveSlots, stackSlots, swapSlots } from '../store/inventory';
 import { Items } from '../store/items';
 
+const isWeapon = (name: string) => name.toUpperCase().startsWith('WEAPON_');
+
+const allowedInSlot = (slot: number, name: string) => {
+  if (slot === 1 || slot === 2) return isWeapon(name);
+  if (slot >= 3 && slot <= 5) return !isWeapon(name);
+  if (slot === 6) return name === 'paperbag';
+  if (slot === 7) return name === 'armour';
+  if (slot === 8) return name === 'phone';
+  if (slot === 9) return name === 'parachute';
+  return true;
+};
+
 export const onDrop = (source: DragSource, target?: DropTarget) => {
   const { inventory: state } = store.getState();
 
@@ -32,6 +44,13 @@ export const onDrop = (source: DragSource, target?: DropTarget) => {
     : findAvailableSlot(sourceSlot, sourceData, targetInventory.items);
 
   if (targetSlot === undefined) return console.error('Target slot undefined!');
+
+  if (
+    targetInventory.type === InventoryType.PLAYER &&
+    !allowedInSlot(targetSlot.slot, sourceSlot.name)
+  ) {
+    return console.log(`Item ${sourceSlot.name} cannot go in slot ${targetSlot.slot}`);
+  }
 
   // If dropping on container slot when opened
   if (targetSlot.metadata?.container !== undefined && state.rightInventory.id === targetSlot.metadata.container)


### PR DESCRIPTION
## Summary
- make right inventory slots interactive using `InventorySlot`
- restrict what items can go in each equipment slot

## Testing
- `npm install` within `ox_inventory-custom/web`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686165d6e934832594e613a1eb3945b8