### PR TITLE
Fix equipment slot dimensions

### DIFF
--- a/ox_inventory-custom/web/src/index.scss
+++ b/ox_inventory-custom/web/src/index.scss
@@ -169,8 +169,8 @@ button:active {
   }
 
   .equipment-slot {
-    width: 80px;
-    height: 80px;
+    width: $gridSize;
+    height: $gridSize;
     margin: 12px;
     border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: 6px;
@@ -723,8 +723,8 @@ button:active {
     }
 
     .equipment-slot {
-      width: 80px;
-      height: 80px;
+      width: $gridSize;
+      height: $gridSize;
       margin: 12px;
       border: 1px solid rgba(255, 255, 255, 0.1);
       border-radius: 6px;


### PR DESCRIPTION
## Summary
- fix equipment grid slot size to match pockets

## Testing
- `npm run build` *(fails: Cannot find module '@reduxjs/toolkit')*

------
https://chatgpt.com/codex/tasks/task_e_686181ca01cc832589e392d6a6c4844a