### PR TITLE
Fix equipment slot drag state

### DIFF
--- a/ox_inventory-custom/web/src/components/inventory/InventorySlot.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/InventorySlot.tsx
@@ -33,7 +33,11 @@ const InventorySlot: React.ForwardRefRenderFunction<HTMLDivElement, SlotProps> =
   const timerRef = useRef<number | null>(null);
 
   const canDrag = useCallback(() => {
-    return canPurchaseItem(item, { type: inventoryType, groups: inventoryGroups }) && canCraftItem(item, inventoryType);
+    return (
+      isSlotWithItem(item) &&
+      canPurchaseItem(item, { type: inventoryType, groups: inventoryGroups }) &&
+      canCraftItem(item, inventoryType)
+    );
   }, [item, inventoryType, inventoryGroups]);
 
   const [{ isDragging }, drag] = useDrag<DragSource, void, { isDragging: boolean }>(


### PR DESCRIPTION
## Summary
- prevent drag setup on empty equipment slots

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686186207594832595d9cc32ea1f10ad