### PR TITLE
Fix equipment slot drop area

### DIFF
--- a/ox_inventory-custom/web/src/components/inventory/InventorySlot.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/InventorySlot.tsx
@@ -33,7 +33,11 @@ const InventorySlot: React.ForwardRefRenderFunction<HTMLDivElement, SlotProps> =
   const timerRef = useRef<number | null>(null);
 
   const canDrag = useCallback(() => {
-    return canPurchaseItem(item, { type: inventoryType, groups: inventoryGroups }) && canCraftItem(item, inventoryType);
+    return (
+      isSlotWithItem(item) &&
+      canPurchaseItem(item, { type: inventoryType, groups: inventoryGroups }) &&
+      canCraftItem(item, inventoryType)
+    );
   }, [item, inventoryType, inventoryGroups]);
 
   const [{ isDragging }, drag] = useDrag<DragSource, void, { isDragging: boolean }>(

--- a/ox_inventory-custom/web/src/slots.scss
+++ b/ox_inventory-custom/web/src/slots.scss
@@ -100,6 +100,8 @@ $bg_ARMOUR: rgba(96, 125, 139, 0.3); // Blue Grey
 
 // inventory slots
 .inventory-slot {
+  width: 100%;
+  height: 100%;
   background-color: rgba(12, 12, 12, 0.4);
   background-repeat: no-repeat;
   background-position: center;


### PR DESCRIPTION
## Summary
- keep inventory slot dimensions when empty so equipment slots remain usable

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686186207594832595d9cc32ea1f10ad