### PR TITLE
Overlay equipment slot icons and add labels

### DIFF
--- a/ox_inventory-custom/web/src/components/inventory/EquipmentInventory.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/EquipmentInventory.tsx
@@ -18,80 +18,98 @@ const EquipmentInventory: React.FC = () => {
     <div className="equipment-inventory">
       <h2 className="pockets-title">Equipment</h2>
       <div className="equipment-grid">
-        <div className="equipment-slot" style={{ gridColumn: 1, gridRow: 1 }}>
-          {!isSlotWithItem(getItem(6)) && (
-            <img src={bagIcon} alt="Backpack" className="equipment-icon" />
-          )}
-          <InventorySlot
-            item={getItem(6)}
-            inventoryId={player.id}
-            inventoryType={player.type}
-            inventoryGroups={groups}
-            showHotkeyNumber={false}
-          />
+        <div className="slot-wrapper" style={{ gridColumn: 1, gridRow: 1 }}>
+          <span>BACKPACK</span>
+          <div className="equipment-slot">
+            {!isSlotWithItem(getItem(6)) && (
+              <img src={bagIcon} alt="Backpack" className="equipment-icon" />
+            )}
+            <InventorySlot
+              item={getItem(6)}
+              inventoryId={player.id}
+              inventoryType={player.type}
+              inventoryGroups={groups}
+              showHotkeyNumber={false}
+            />
+          </div>
         </div>
         <div className="equipment-placeholder" style={{ gridColumn: 2, gridRow: '1 / span 3' }}>
           <span>PLAYER MODEL</span>
         </div>
-        <div className="equipment-slot" style={{ gridColumn: 3, gridRow: 1 }}>
-          {!isSlotWithItem(getItem(9)) && (
-            <img src={parachuteIcon} alt="Parachute" className="equipment-icon" />
-          )}
-          <InventorySlot
-            item={getItem(9)}
-            inventoryId={player.id}
-            inventoryType={player.type}
-            inventoryGroups={groups}
-            showHotkeyNumber={false}
-          />
+        <div className="slot-wrapper" style={{ gridColumn: 3, gridRow: 1 }}>
+          <span>PARACHUTE</span>
+          <div className="equipment-slot">
+            {!isSlotWithItem(getItem(9)) && (
+              <img src={parachuteIcon} alt="Parachute" className="equipment-icon" />
+            )}
+            <InventorySlot
+              item={getItem(9)}
+              inventoryId={player.id}
+              inventoryType={player.type}
+              inventoryGroups={groups}
+              showHotkeyNumber={false}
+            />
+          </div>
         </div>
-        <div className="equipment-slot" style={{ gridColumn: 1, gridRow: 2 }}>
-          {!isSlotWithItem(getItem(7)) && (
-            <img src={armourIcon} alt="Body Armour" className="equipment-icon" />
-          )}
-          <InventorySlot
-            item={getItem(7)}
-            inventoryId={player.id}
-            inventoryType={player.type}
-            inventoryGroups={groups}
-            showHotkeyNumber={false}
-          />
+        <div className="slot-wrapper" style={{ gridColumn: 1, gridRow: 2 }}>
+          <span>ARMOUR</span>
+          <div className="equipment-slot">
+            {!isSlotWithItem(getItem(7)) && (
+              <img src={armourIcon} alt="Body Armour" className="equipment-icon" />
+            )}
+            <InventorySlot
+              item={getItem(7)}
+              inventoryId={player.id}
+              inventoryType={player.type}
+              inventoryGroups={groups}
+              showHotkeyNumber={false}
+            />
+          </div>
         </div>
-        <div className="equipment-slot" style={{ gridColumn: 3, gridRow: 2 }}>
-          {!isSlotWithItem(getItem(1)) && (
-            <img src={weaponIcon} alt="Weapon Slot 1" className="equipment-icon" />
-          )}
-          <InventorySlot
-            item={getItem(1)}
-            inventoryId={player.id}
-            inventoryType={player.type}
-            inventoryGroups={groups}
-            showHotkeyNumber
-          />
+        <div className="slot-wrapper" style={{ gridColumn: 3, gridRow: 2 }}>
+          <span>WEAPON 1</span>
+          <div className="equipment-slot">
+            {!isSlotWithItem(getItem(1)) && (
+              <img src={weaponIcon} alt="Weapon Slot 1" className="equipment-icon" />
+            )}
+            <InventorySlot
+              item={getItem(1)}
+              inventoryId={player.id}
+              inventoryType={player.type}
+              inventoryGroups={groups}
+              showHotkeyNumber
+            />
+          </div>
         </div>
-        <div className="equipment-slot" style={{ gridColumn: 1, gridRow: 3 }}>
-          {!isSlotWithItem(getItem(8)) && (
-            <img src={phoneIcon} alt="Phone" className="equipment-icon" />
-          )}
-          <InventorySlot
-            item={getItem(8)}
-            inventoryId={player.id}
-            inventoryType={player.type}
-            inventoryGroups={groups}
-            showHotkeyNumber={false}
-          />
+        <div className="slot-wrapper" style={{ gridColumn: 1, gridRow: 3 }}>
+          <span>PHONE</span>
+          <div className="equipment-slot">
+            {!isSlotWithItem(getItem(8)) && (
+              <img src={phoneIcon} alt="Phone" className="equipment-icon" />
+            )}
+            <InventorySlot
+              item={getItem(8)}
+              inventoryId={player.id}
+              inventoryType={player.type}
+              inventoryGroups={groups}
+              showHotkeyNumber={false}
+            />
+          </div>
         </div>
-        <div className="equipment-slot" style={{ gridColumn: 3, gridRow: 3 }}>
-          {!isSlotWithItem(getItem(2)) && (
-            <img src={weaponIcon} alt="Weapon Slot 2" className="equipment-icon" />
-          )}
-          <InventorySlot
-            item={getItem(2)}
-            inventoryId={player.id}
-            inventoryType={player.type}
-            inventoryGroups={groups}
-            showHotkeyNumber
-          />
+        <div className="slot-wrapper" style={{ gridColumn: 3, gridRow: 3 }}>
+          <span>WEAPON 2</span>
+          <div className="equipment-slot">
+            {!isSlotWithItem(getItem(2)) && (
+              <img src={weaponIcon} alt="Weapon Slot 2" className="equipment-icon" />
+            )}
+            <InventorySlot
+              item={getItem(2)}
+              inventoryId={player.id}
+              inventoryType={player.type}
+              inventoryGroups={groups}
+              showHotkeyNumber
+            />
+          </div>
         </div>
       </div>
       <div className="hotkey-row">

--- a/ox_inventory-custom/web/src/components/inventory/InventorySlot.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/InventorySlot.tsx
@@ -33,7 +33,11 @@ const InventorySlot: React.ForwardRefRenderFunction<HTMLDivElement, SlotProps> =
   const timerRef = useRef<number | null>(null);
 
   const canDrag = useCallback(() => {
-    return canPurchaseItem(item, { type: inventoryType, groups: inventoryGroups }) && canCraftItem(item, inventoryType);
+    return (
+      isSlotWithItem(item) &&
+      canPurchaseItem(item, { type: inventoryType, groups: inventoryGroups }) &&
+      canCraftItem(item, inventoryType)
+    );
   }, [item, inventoryType, inventoryGroups]);
 
   const [{ isDragging }, drag] = useDrag<DragSource, void, { isDragging: boolean }>(

--- a/ox_inventory-custom/web/src/components/inventory/RightInventory.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/RightInventory.tsx
@@ -18,80 +18,98 @@ const RightInventory: React.FC = () => {
     <div className="right-inventory">
       <h2 className="pockets-title">Equipment</h2>
       <div className="equipment-grid">
-        <div className="equipment-slot" style={{ gridColumn: 1, gridRow: 1 }}>
-          {!isSlotWithItem(getItem(6)) && (
-            <img src={bagIcon} alt="Backpack" className="equipment-icon" />
-          )}
-          <InventorySlot
-            item={getItem(6)}
-            inventoryId={player.id}
-            inventoryType={player.type}
-            inventoryGroups={groups}
-            showHotkeyNumber={false}
-          />
+        <div className="slot-wrapper" style={{ gridColumn: 1, gridRow: 1 }}>
+          <span>BACKPACK</span>
+          <div className="equipment-slot">
+            {!isSlotWithItem(getItem(6)) && (
+              <img src={bagIcon} alt="Backpack" className="equipment-icon" />
+            )}
+            <InventorySlot
+              item={getItem(6)}
+              inventoryId={player.id}
+              inventoryType={player.type}
+              inventoryGroups={groups}
+              showHotkeyNumber={false}
+            />
+          </div>
         </div>
         <div className="equipment-placeholder" style={{ gridColumn: 2, gridRow: '1 / span 3' }}>
           <span>PLAYER MODEL</span>
         </div>
-        <div className="equipment-slot" style={{ gridColumn: 3, gridRow: 1 }}>
-          {!isSlotWithItem(getItem(9)) && (
-            <img src={parachuteIcon} alt="Parachute" className="equipment-icon" />
-          )}
-          <InventorySlot
-            item={getItem(9)}
-            inventoryId={player.id}
-            inventoryType={player.type}
-            inventoryGroups={groups}
-            showHotkeyNumber={false}
-          />
+        <div className="slot-wrapper" style={{ gridColumn: 3, gridRow: 1 }}>
+          <span>PARACHUTE</span>
+          <div className="equipment-slot">
+            {!isSlotWithItem(getItem(9)) && (
+              <img src={parachuteIcon} alt="Parachute" className="equipment-icon" />
+            )}
+            <InventorySlot
+              item={getItem(9)}
+              inventoryId={player.id}
+              inventoryType={player.type}
+              inventoryGroups={groups}
+              showHotkeyNumber={false}
+            />
+          </div>
         </div>
-        <div className="equipment-slot" style={{ gridColumn: 1, gridRow: 2 }}>
-          {!isSlotWithItem(getItem(7)) && (
-            <img src={armourIcon} alt="Body Armour" className="equipment-icon" />
-          )}
-          <InventorySlot
-            item={getItem(7)}
-            inventoryId={player.id}
-            inventoryType={player.type}
-            inventoryGroups={groups}
-            showHotkeyNumber={false}
-          />
+        <div className="slot-wrapper" style={{ gridColumn: 1, gridRow: 2 }}>
+          <span>ARMOUR</span>
+          <div className="equipment-slot">
+            {!isSlotWithItem(getItem(7)) && (
+              <img src={armourIcon} alt="Body Armour" className="equipment-icon" />
+            )}
+            <InventorySlot
+              item={getItem(7)}
+              inventoryId={player.id}
+              inventoryType={player.type}
+              inventoryGroups={groups}
+              showHotkeyNumber={false}
+            />
+          </div>
         </div>
-        <div className="equipment-slot" style={{ gridColumn: 3, gridRow: 2 }}>
-          {!isSlotWithItem(getItem(1)) && (
-            <img src={weaponIcon} alt="Weapon Slot 1" className="equipment-icon" />
-          )}
-          <InventorySlot
-            item={getItem(1)}
-            inventoryId={player.id}
-            inventoryType={player.type}
-            inventoryGroups={groups}
-            showHotkeyNumber
-          />
+        <div className="slot-wrapper" style={{ gridColumn: 3, gridRow: 2 }}>
+          <span>WEAPON 1</span>
+          <div className="equipment-slot">
+            {!isSlotWithItem(getItem(1)) && (
+              <img src={weaponIcon} alt="Weapon Slot 1" className="equipment-icon" />
+            )}
+            <InventorySlot
+              item={getItem(1)}
+              inventoryId={player.id}
+              inventoryType={player.type}
+              inventoryGroups={groups}
+              showHotkeyNumber
+            />
+          </div>
         </div>
-        <div className="equipment-slot" style={{ gridColumn: 1, gridRow: 3 }}>
-          {!isSlotWithItem(getItem(8)) && (
-            <img src={phoneIcon} alt="Phone" className="equipment-icon" />
-          )}
-          <InventorySlot
-            item={getItem(8)}
-            inventoryId={player.id}
-            inventoryType={player.type}
-            inventoryGroups={groups}
-            showHotkeyNumber={false}
-          />
+        <div className="slot-wrapper" style={{ gridColumn: 1, gridRow: 3 }}>
+          <span>PHONE</span>
+          <div className="equipment-slot">
+            {!isSlotWithItem(getItem(8)) && (
+              <img src={phoneIcon} alt="Phone" className="equipment-icon" />
+            )}
+            <InventorySlot
+              item={getItem(8)}
+              inventoryId={player.id}
+              inventoryType={player.type}
+              inventoryGroups={groups}
+              showHotkeyNumber={false}
+            />
+          </div>
         </div>
-        <div className="equipment-slot" style={{ gridColumn: 3, gridRow: 3 }}>
-          {!isSlotWithItem(getItem(2)) && (
-            <img src={weaponIcon} alt="Weapon Slot 2" className="equipment-icon" />
-          )}
-          <InventorySlot
-            item={getItem(2)}
-            inventoryId={player.id}
-            inventoryType={player.type}
-            inventoryGroups={groups}
-            showHotkeyNumber
-          />
+        <div className="slot-wrapper" style={{ gridColumn: 3, gridRow: 3 }}>
+          <span>WEAPON 2</span>
+          <div className="equipment-slot">
+            {!isSlotWithItem(getItem(2)) && (
+              <img src={weaponIcon} alt="Weapon Slot 2" className="equipment-icon" />
+            )}
+            <InventorySlot
+              item={getItem(2)}
+              inventoryId={player.id}
+              inventoryType={player.type}
+              inventoryGroups={groups}
+              showHotkeyNumber
+            />
+          </div>
         </div>
       </div>
       <div className="hotkey-row">

--- a/ox_inventory-custom/web/src/index.scss
+++ b/ox_inventory-custom/web/src/index.scss
@@ -176,11 +176,12 @@ button:active {
     border-radius: 6px;
     background: rgba(0, 0, 0, 0.3);
     backdrop-filter: blur(4px);
+    position: relative;
     display: flex;
     align-items: center;
     justify-content: center;
     text-align: center;
-  }
+    }
 
   .equipment-placeholder {
     width: 120px;
@@ -208,11 +209,22 @@ button:active {
     gap: 4px;
   }
 
+  .slot-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+  }
+
   .equipment-icon {
-    width: 60px;
-    height: 60px;
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
     object-fit: contain;
+    opacity: 0.5;
     pointer-events: none;
+    z-index: 0;
   }
 }
 
@@ -730,6 +742,7 @@ button:active {
       border-radius: 6px;
       background: rgba(0, 0, 0, 0.3);
       backdrop-filter: blur(4px);
+      position: relative;
       display: flex;
       align-items: center;
       justify-content: center;

--- a/ox_inventory-custom/web/src/slots.scss
+++ b/ox_inventory-custom/web/src/slots.scss
@@ -100,12 +100,15 @@ $bg_ARMOUR: rgba(96, 125, 139, 0.3); // Blue Grey
 
 // inventory slots
 .inventory-slot {
+  width: 100%;
+  height: 100%;
   background-color: rgba(12, 12, 12, 0.4);
   background-repeat: no-repeat;
   background-position: center;
   border-radius: $mainRadius;
   image-rendering: -webkit-optimize-contrast;
   position: relative;
+  z-index: 1;
   background-size: cover;
   color: #c1c2c5;
   border: 0.1px solid #2d2f3a;


### PR DESCRIPTION
## Summary
- make equipment icons background images so slots remain fully draggable
- show text labels above every equipment slot
- allow `InventorySlot` to appear on top

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686186207594832595d9cc32ea1f10ad