### PR TITLE
Replace player model placeholder with character image

### DIFF
--- a/ox_inventory-custom/web/src/components/inventory/EquipmentInventory.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/EquipmentInventory.tsx
@@ -4,6 +4,7 @@ import parachuteIcon from '../../../images/parachute.png?url';
 import phoneIcon from '../../../images/phone.png?url';
 import weaponIcon from '../../../images/WEAPON_PISTOL.png?url';
 import bagIcon from '../../../images/garbage.png?url';
+import characterGrid from '../../../images/character_grid.png?url';
 import InventorySlot from './InventorySlot';
 import { useAppSelector } from '../../store';
 import { selectEquipmentInventory } from '../../store/inventory';
@@ -34,7 +35,7 @@ const EquipmentInventory: React.FC = () => {
           </div>
         </div>
         <div className="equipment-placeholder" style={{ gridColumn: 2, gridRow: '1 / span 3' }}>
-          <span>PLAYER MODEL</span>
+          <img src={characterGrid} alt="Player Model" className="character-grid" />
         </div>
         <div className="slot-wrapper" style={{ gridColumn: 3, gridRow: 1 }}>
           <span>PARACHUTE</span>

--- a/ox_inventory-custom/web/src/components/inventory/RightInventory.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/RightInventory.tsx
@@ -4,6 +4,7 @@ import parachuteIcon from '../../../images/parachute.png?url';
 import phoneIcon from '../../../images/phone.png?url';
 import weaponIcon from '../../../images/WEAPON_PISTOL.png?url';
 import bagIcon from '../../../images/garbage.png?url';
+import characterGrid from '../../../images/character_grid.png?url';
 import InventorySlot from './InventorySlot';
 import { useAppSelector } from '../../store';
 import { selectEquipmentInventory } from '../../store/inventory';
@@ -34,7 +35,7 @@ const RightInventory: React.FC = () => {
           </div>
         </div>
         <div className="equipment-placeholder" style={{ gridColumn: 2, gridRow: '1 / span 3' }}>
-          <span>PLAYER MODEL</span>
+          <img src={characterGrid} alt="Player Model" className="character-grid" />
         </div>
         <div className="slot-wrapper" style={{ gridColumn: 3, gridRow: 1 }}>
           <span>PARACHUTE</span>

--- a/ox_inventory-custom/web/src/index.scss
+++ b/ox_inventory-custom/web/src/index.scss
@@ -194,6 +194,12 @@ button:active {
     border: 1px dashed rgba(255, 255, 255, 0.15);
     color: rgba(255, 255, 255, 0.6);
     font-size: 0.7rem;
+    img.character-grid {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      object-position: bottom;
+    }
   }
 
   .hotkey-row {
@@ -775,6 +781,12 @@ button:active {
       border: 1px dashed rgba(122, 11, 150, 0.15);
       color: rgba(255, 255, 255, 0.6);
       font-size: 0.7rem;
+      img.character-grid {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        object-position: bottom;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- display `character_grid.png` in equipment placeholder
- style placeholder to fit the grid
- update inventory components to use the image

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686192f58bec8325a2ee2f2c79746264