### PR TITLE
Expand equipment panel and grid

### DIFF
--- a/ox_inventory-custom/web/src/components/inventory/EquipmentInventory.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/EquipmentInventory.tsx
@@ -4,6 +4,7 @@ import parachuteIcon from '../../../images/parachute.png?url';
 import phoneIcon from '../../../images/phone.png?url';
 import weaponIcon from '../../../images/WEAPON_PISTOL.png?url';
 import bagIcon from '../../../images/garbage.png?url';
+import characterGrid from '../../../images/character_grid.png?url';
 import InventorySlot from './InventorySlot';
 import { useAppSelector } from '../../store';
 import { selectEquipmentInventory } from '../../store/inventory';
@@ -34,7 +35,7 @@ const EquipmentInventory: React.FC = () => {
           </div>
         </div>
         <div className="equipment-placeholder" style={{ gridColumn: 2, gridRow: '1 / span 3' }}>
-          <span>PLAYER MODEL</span>
+          <img src={characterGrid} alt="Player Model" className="character-grid" />
         </div>
         <div className="slot-wrapper" style={{ gridColumn: 3, gridRow: 1 }}>
           <span>PARACHUTE</span>

--- a/ox_inventory-custom/web/src/components/inventory/RightInventory.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/RightInventory.tsx
@@ -4,6 +4,7 @@ import parachuteIcon from '../../../images/parachute.png?url';
 import phoneIcon from '../../../images/phone.png?url';
 import weaponIcon from '../../../images/WEAPON_PISTOL.png?url';
 import bagIcon from '../../../images/garbage.png?url';
+import characterGrid from '../../../images/character_grid.png?url';
 import InventorySlot from './InventorySlot';
 import { useAppSelector } from '../../store';
 import { selectEquipmentInventory } from '../../store/inventory';
@@ -34,7 +35,7 @@ const RightInventory: React.FC = () => {
           </div>
         </div>
         <div className="equipment-placeholder" style={{ gridColumn: 2, gridRow: '1 / span 3' }}>
-          <span>PLAYER MODEL</span>
+          <img src={characterGrid} alt="Player Model" className="character-grid" />
         </div>
         <div className="slot-wrapper" style={{ gridColumn: 3, gridRow: 1 }}>
           <span>PARACHUTE</span>

--- a/ox_inventory-custom/web/src/index.scss
+++ b/ox_inventory-custom/web/src/index.scss
@@ -147,7 +147,7 @@ button:active {
   background: rgba(0, 0, 0, 0.3);
   backdrop-filter: blur(6px);
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.4);
-  padding: 5px;
+  padding: 10px;
   
   .inventory-grid-container {
     overflow-y: auto;
@@ -185,8 +185,8 @@ button:active {
     }
 
   .equipment-placeholder {
-    width: 120px;
-    height: 280px;
+    width: $gridSize;
+    height: $gridSize * 5;
     margin: 12px;
     display: flex;
     align-items: center;
@@ -194,6 +194,12 @@ button:active {
     border: 1px dashed rgba(255, 255, 255, 0.15);
     color: rgba(255, 255, 255, 0.6);
     font-size: 0.7rem;
+    img.character-grid {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      object-position: bottom;
+    }
   }
 
   .hotkey-row {
@@ -255,7 +261,7 @@ button:active {
   background: rgba(0, 0, 0, 0.3);
   backdrop-filter: blur(6px);
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.4);
-  padding: 5px;
+  padding: 10px;
 
   .inventory-grid-container {
     overflow-y: auto;
@@ -766,8 +772,8 @@ button:active {
     }
 
     .equipment-placeholder {
-      width: 120px;
-      height: 280px;
+      width: $gridSize;
+      height: $gridSize * 5;
       margin: 12px;
       display: flex;
       align-items: center;
@@ -775,6 +781,12 @@ button:active {
       border: 1px dashed rgba(122, 11, 150, 0.15);
       color: rgba(255, 255, 255, 0.6);
       font-size: 0.7rem;
+      img.character-grid {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        object-position: bottom;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- widen equipment and left inventory panels
- extend character grid placeholder to 5 slot height

## Testing
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686192f58bec8325a2ee2f2c79746264