### PR TITLE
Add rarity-based highlights and smaller weight bar

### DIFF
--- a/ox_inventory-custom/data/items.lua
+++ b/ox_inventory-custom/data/items.lua
@@ -68,14 +68,15 @@ return {
 		label = 'Dirty Money',
 	},
 
-	['burger'] = {
-		label = 'Burger',
-		weight = 220,
-		client = {
-			status = { hunger = 200000 },
-			anim = 'eating',
-			prop = 'burger',
-			usetime = 2500,
+        ['burger'] = {
+                label = 'Burger',
+                weight = 220,
+                metadata = { quality = 'Common' },
+                client = {
+                        status = { hunger = 200000 },
+                        anim = 'eating',
+                        prop = 'burger',
+                        usetime = 2500,
 			notification = 'You ate a delicious burger'
 		},
 	},
@@ -175,12 +176,13 @@ return {
 		}
 	},
 
-	['water'] = {
-		label = 'Water',
-		weight = 500,
-		client = {
-			status = { thirst = 200000 },
-			anim = { dict = 'mp_player_intdrink', clip = 'loop_bottle' },
+        ['water'] = {
+                label = 'Water',
+                weight = 500,
+                metadata = { quality = 'Common' },
+                client = {
+                        status = { thirst = 200000 },
+                        anim = { dict = 'mp_player_intdrink', clip = 'loop_bottle' },
 			prop = { model = `prop_ld_flow_bottle`, pos = vec3(0.03, 0.03, 0.02), rot = vec3(0.0, 0.0, -1.5) },
 			usetime = 2500,
 			cancel = true,
@@ -195,15 +197,16 @@ return {
 		allowArmed = true
 	},
 
-	['armour'] = {
-		label = 'Bulletproof Vest',
-		weight = 3000,
-		stack = false,
-		client = {
-			anim = { dict = 'clothingshirt', clip = 'try_shirt_positive_d' },
-			usetime = 3500
-		}
-	},
+        ['armour'] = {
+                label = 'Bulletproof Vest',
+                weight = 3000,
+                metadata = { quality = 'Rare' },
+                stack = false,
+                client = {
+                        anim = { dict = 'clothingshirt', clip = 'try_shirt_positive_d' },
+                        usetime = 3500
+                }
+        },
 
 	['clothing'] = {
 		label = 'Clothing',
@@ -334,14 +337,15 @@ return {
 		}
 	},
 
-	["diamond_ring"] = {
-		label = "Diamond Ring",
-		weight = 200,
-		stack = true,
-		close = false,
-		description = "",
-		client = {
-			image = "diamond_ring.png",
+        ["diamond_ring"] = {
+                label = "Diamond Ring",
+                weight = 200,
+                metadata = { quality = 'Legendary' },
+                stack = true,
+                close = false,
+                description = "",
+                client = {
+                        image = "diamond_ring.png",
 		}
 	},
 

--- a/ox_inventory-custom/web/src/components/inventory/InventoryGrid.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/InventoryGrid.tsx
@@ -26,6 +26,7 @@ const InventoryGrid: React.FC<InventoryGridProps> = ({ inventory, showSlotNumber
             <p>{inventory.label}</p>
             {inventory.maxWeight && (
               <p>
+                <span className="weight-icon">⚖</span>
                 {weight / 1000}/{inventory.maxWeight / 1000}kg
               </p>
             )}

--- a/ox_inventory-custom/web/src/components/inventory/InventorySlot.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/InventorySlot.tsx
@@ -134,7 +134,7 @@ const InventorySlot: React.ForwardRefRenderFunction<HTMLDivElement, SlotProps> =
       ref={refs}
       onContextMenu={handleContext}
       onClick={handleClick}
-      className={`inventory-slot ${item?.name ? `inventory-slot-${item.name.toLowerCase()}` : ''}`}
+      className={`inventory-slot ${quality ? `rarity-${quality.toLowerCase()}` : ''}`}
       style={{
         filter:
           !canPurchaseItem(item, { type: inventoryType, groups: inventoryGroups }) || !canCraftItem(item, inventoryType)

--- a/ox_inventory-custom/web/src/index.scss
+++ b/ox_inventory-custom/web/src/index.scss
@@ -433,6 +433,10 @@ button:active {
   p {
     font-size: 1rem;
   }
+
+  .weight-icon {
+    padding-right: 4px;
+  }
 }
 
 .inventory-grid-container {
@@ -644,18 +648,19 @@ button:active {
   padding-right: 7px;
 }
 
+
 .weight-bar-WR {
   border-radius: $mainRadius;
   padding: 1px;
   background: $mainGradient;
-  margin-bottom: 10px;
+  margin-bottom: 5px;
   animation: rainbow 22s infinite linear alternate;
 }
 
 .weight-bar {
   background: rgba(0, 0, 0, 0.8);
   border: 1px inset rgba(0, 0, 0, 0.1);
-  height: 3vh;
+  height: 1vh;
   border-radius: $secondRadius;
   overflow: hidden;
 }
@@ -976,6 +981,10 @@ button:active {
     p {
       font-size: 2rem;
     }
+
+    .weight-icon {
+      padding-right: 8px;
+    }
   }
 
   .inventory-grid-container {
@@ -1130,7 +1139,7 @@ button:active {
 
   .weight-bar {
     border: 1px inset rgba(0, 0, 0, 0.1);
-    height: 3vh;
+    height: 1vh;
     border-radius: $secondRadius4K;
   }
 

--- a/ox_inventory-custom/web/src/slots.scss
+++ b/ox_inventory-custom/web/src/slots.scss
@@ -13,6 +13,13 @@ $bg_OTHERS: rgba(255, 87, 34, 0.3); // Deep Orange
 $bg_DRUGS: rgba(244, 67, 54, 0.3); // Red
 $bg_ARMOUR: rgba(96, 125, 139, 0.3); // Blue Grey
 
+// rarity backgrounds
+$bg_COMMON: rgba(255, 255, 255, 0.1); // gray
+$bg_UNCOMMON: rgba(76, 175, 80, 0.3); // green
+$bg_RARE: rgba(63, 81, 181, 0.3); // blue
+$bg_EPIC: rgba(156, 39, 176, 0.3); // purple
+$bg_LEGENDARY: rgba(255, 193, 7, 0.3); // gold
+
 .item-image {
   position: relative;
   z-index: 0;
@@ -121,6 +128,26 @@ $bg_ARMOUR: rgba(96, 125, 139, 0.3); // Blue Grey
     border: 0.1px solid $primary;
     box-shadow: 0px 0px 6px 0px rgba(154, 72, 208, 0.7);
     transition: all 0.3s ease,
+  }
+
+  &.rarity-common {
+    background-color: $bg_COMMON;
+  }
+
+  &.rarity-uncommon {
+    background-color: $bg_UNCOMMON;
+  }
+
+  &.rarity-rare {
+    background-color: $bg_RARE;
+  }
+
+  &.rarity-epic {
+    background-color: $bg_EPIC;
+  }
+
+  &.rarity-legendary {
+    background-color: $bg_LEGENDARY;
   }
 
   // CLOTHING


### PR DESCRIPTION
## Summary
- mark some items with rarity metadata
- display weight with an icon
- color slots using rarity classes instead of item type
- make weight bar thinner and adjust 4K styles

## Testing
- `npm install --silent` *(fails: blocked by proxy)*
- `npm run build` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_686434d693c0832593d1427ef521c99b