### PR TITLE
Add confirmable split menu

### DIFF
--- a/ox_inventory-custom/web/src/components/inventory/SplitDialog.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/SplitDialog.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { fetchNui } from '../../utils/fetchNui';
 import {
   FloatingFocusManager,
   FloatingOverlay,
@@ -27,17 +28,23 @@ const SplitDialog: React.FC<Props> = ({ visible, onClose, item }) => {
 
   const update = (n: number) => setQty(Math.min(max, Math.max(1, n)));
 
+  const confirm = () => {
+    if (!item) return;
+    fetchNui('splitItem', { slot: item.slot, count: qty });
+    onClose();
+  };
+
   return (
     <>
       {isMounted && (
         <FloatingPortal>
-          <FloatingOverlay lockScroll className="useful-controls-dialog-overlay" data-open={visible} style={styles}>
+          <FloatingOverlay lockScroll className="split-dialog-overlay" data-open={visible} style={styles}>
             <FloatingFocusManager context={context}>
-              <div ref={refs.setFloating} {...getFloatingProps()} className="useful-controls-dialog" style={styles}>
-                <div className="useful-controls-dialog-WR">
-                  <div className="useful-controls-dialog-title">
+              <div ref={refs.setFloating} {...getFloatingProps()} className="split-dialog" style={styles}>
+                <div className="split-dialog-WR">
+                  <div className="split-dialog-title">
                     <p>SPLIT</p>
-                    <div className="useful-controls-dialog-close" onClick={onClose}>
+                    <div className="split-dialog-close" onClick={onClose}>
                       ×
                     </div>
                   </div>
@@ -52,6 +59,7 @@ const SplitDialog: React.FC<Props> = ({ visible, onClose, item }) => {
                     </div>
                     <div style={{ display: 'flex', gap: '8px', justifyContent: 'center' }}>
                       <button onClick={onClose}>{Locale.ui_cancel || 'Cancel'}</button>
+                      <button onClick={confirm}>{Locale.ui_confirm || 'Confirm'}</button>
                     </div>
                   </div>
                 </div>

--- a/ox_inventory-custom/web/src/index.scss
+++ b/ox_inventory-custom/web/src/index.scss
@@ -412,6 +412,61 @@ button:active {
   color: grey !important;
 }
 
+// split dialog styling
+.split-dialog {
+  background-color: $mainColor;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: $textColor;
+  min-width: 20vw;
+  min-height: 20vh;
+  display: flex;
+  flex-direction: column;
+  padding: 3px;
+  border-radius: $mainRadius;
+  background: $mainGradient;
+  animation: rainbow 22s infinite linear alternate;
+  gap: 16px;
+}
+
+.split-dialog-WR {
+  background: #121212;
+  min-height: 20vh;
+  padding: 1vh;
+  border-radius: $secondRadius;
+}
+
+.split-dialog-overlay {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.split-dialog-title {
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 1.2rem;
+  margin-left: 0.3rem;
+}
+
+.split-dialog-close {
+  width: 25px;
+  height: 25px;
+  padding: 6px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: $mainRadius;
+  fill: $textColor;
+
+  &:hover {
+    background-color: $secondaryColorHighlight;
+    cursor: pointer;
+  }
+}
+
 // Dialog is used fro useful controls window
 // inventory grids
 .inventory-grid-wrapper {
@@ -1148,6 +1203,66 @@ button:active {
     background: rgba(0, 0, 0, 0.8);
     height: 3px;
     overflow: hidden;
+  }
+
+  // split dialog styling
+  .split-dialog {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    display: flex;
+    flex-direction: column;
+    padding: 16px;
+    gap: 22px;
+
+    min-width: 20vw;
+    min-height: 20vh;
+
+    background: rgba(24, 24, 24, 0.1);
+    backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    box-shadow: 0 0 24px rgba(0, 0, 0, 0.6);
+    border-radius: 18px;
+
+    color: $textColor;
+    font-family: $mainFont;
+  }
+
+  .split-dialog-WR {
+    background: #121212;
+    min-height: 20vh;
+    padding: 1vh;
+    border-radius: $secondRadius;
+  }
+
+  .split-dialog-overlay {
+    background-color: rgba(0, 0, 0, 0.5);
+  }
+
+  .split-dialog-title {
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 2.2rem;
+    margin-left: 0.3rem;
+  }
+
+  .split-dialog-close {
+    width: 50px;
+    height: 50px;
+    padding: 12px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: $mainRadius4K;
+    fill: $textColor;
+
+    &:hover {
+      background-color: $secondaryColorHighlight;
+      cursor: pointer;
+    }
   }
 
   .PanelClose {


### PR DESCRIPTION
## Summary
- tweak split dialog component styling and add confirm button
- add smaller menu styles for splitting item stacks

## Testing
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_68645243502c8325882a012f9660d457