### PR TITLE
Add inventory toggle with Q/E keys

### DIFF
--- a/ox_inventory-custom/web/src/components/inventory/InventoryTabs.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/InventoryTabs.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+interface Props {
+  showEquipment: boolean;
+  setShowEquipment: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const InventoryTabs: React.FC<Props> = ({ showEquipment, setShowEquipment }) => {
+  return (
+    <div className="inventory-tabs">
+      <div
+        className={`tab-btn ${!showEquipment ? 'active' : ''}`}
+        onClick={() => setShowEquipment(false)}
+      >
+        Q Inventory
+      </div>
+      <div
+        className={`tab-btn ${showEquipment ? 'active' : ''}`}
+        onClick={() => setShowEquipment(true)}
+      >
+        E Equipment
+      </div>
+    </div>
+  );
+};
+
+export default InventoryTabs;

--- a/ox_inventory-custom/web/src/components/inventory/index.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import useNuiEvent from '../../hooks/useNuiEvent';
 import InventoryHotbar from './InventoryHotbar';
 import { useAppDispatch } from '../../store';
@@ -12,10 +12,16 @@ import { closeTooltip } from '../../store/tooltip';
 import InventoryContext from './InventoryContext';
 import { closeContextMenu } from '../../store/contextMenu';
 import Fade from '../utils/transitions/Fade';
+import useKeyPress from '../../hooks/useKeyPress';
+import InventoryTabs from './InventoryTabs';
 
 const Inventory: React.FC = () => {
   const [inventoryVisible, setInventoryVisible] = useState(false);
+  const [showEquipment, setShowEquipment] = useState(false);
   const dispatch = useAppDispatch();
+
+  const qPressed = useKeyPress('q');
+  const ePressed = useKeyPress('e');
 
   useNuiEvent<boolean>('setInventoryVisible', setInventoryVisible);
   useNuiEvent<false>('closeInventory', () => {
@@ -24,6 +30,18 @@ const Inventory: React.FC = () => {
     dispatch(closeTooltip());
   });
   useExitListener(setInventoryVisible);
+
+  useEffect(() => {
+    if (inventoryVisible && ePressed) {
+      setShowEquipment(true);
+    }
+  }, [ePressed, inventoryVisible]);
+
+  useEffect(() => {
+    if (inventoryVisible && qPressed) {
+      setShowEquipment(false);
+    }
+  }, [qPressed, inventoryVisible]);
 
   useNuiEvent<{
     leftInventory?: InventoryProps;
@@ -43,7 +61,13 @@ const Inventory: React.FC = () => {
     <>
       <Fade in={inventoryVisible}>
         <div className="inventory-wrapper">
-          <RightInventory />
+          <InventoryTabs
+            showEquipment={showEquipment}
+            setShowEquipment={setShowEquipment}
+          />
+          <Fade in={showEquipment}>
+            <RightInventory />
+          </Fade>
           <LeftInventory />
           <Tooltip />
           <InventoryContext />

--- a/ox_inventory-custom/web/src/index.scss
+++ b/ox_inventory-custom/web/src/index.scss
@@ -129,6 +129,30 @@ button:active {
   z-index: 9999;
 }
 
+.inventory-tabs {
+  position: fixed;
+  top: 2%;
+  right: 2%;
+  display: flex;
+  gap: 8px;
+  z-index: 10000;
+}
+
+.inventory-tabs .tab-btn {
+  padding: 6px 12px;
+  background: rgba(0, 0, 0, 0.5);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: bold;
+  cursor: pointer;
+  color: #fff;
+}
+
+.inventory-tabs .tab-btn.active {
+  background: rgba(255, 255, 255, 0.15);
+}
+
 .pockets-header {
   display: flex;
   justify-content: space-between;
@@ -743,6 +767,18 @@ button:active {
   .inventory-wrapper {
     gap: 40px;
     z-index: 9999;
+  }
+
+  .inventory-tabs {
+    top: 2%;
+    right: 2%;
+    gap: 12px;
+  }
+
+  .inventory-tabs .tab-btn {
+    font-size: 1.6rem;
+    padding: 10px 16px;
+    border-radius: $mainRadius4K;
   }
 
   .right-inventory {


### PR DESCRIPTION
## Summary
- add InventoryTabs component for switching between inventory and equipment
- toggle equipment on keypress Q/E
- style new buttons in SCSS
- hide/show RightInventory with fade effect

## Testing
- `npm install` *(fails without network access)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68655adb490c8325b002fe0b8eba761f