### PR TITLE
Add equipment toggle UI

### DIFF
--- a/ox_inventory-custom/web/src/components/inventory/index.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import useNuiEvent from '../../hooks/useNuiEvent';
 import InventoryHotbar from './InventoryHotbar';
 import { useAppDispatch } from '../../store';
@@ -7,6 +7,7 @@ import { useExitListener } from '../../hooks/useExitListener';
 import type { Inventory as InventoryProps } from '../../typings';
 import EquipmentInventory from './EquipmentInventory';
 import LeftInventory from './LeftInventory';
+import InventoryTabs from './InventoryTabs';
 import Tooltip from '../utils/Tooltip';
 import { closeTooltip } from '../../store/tooltip';
 import InventoryContext from './InventoryContext';
@@ -15,6 +16,7 @@ import Fade from '../utils/transitions/Fade';
 
 const Inventory: React.FC = () => {
   const [inventoryVisible, setInventoryVisible] = useState(false);
+  const [showEquipment, setShowEquipment] = useState(true);
   const dispatch = useAppDispatch();
 
   useNuiEvent<boolean>('setInventoryVisible', setInventoryVisible);
@@ -39,11 +41,27 @@ const Inventory: React.FC = () => {
     dispatch(setAdditionalMetadata(data));
   });
 
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() === 'e') setShowEquipment(true);
+      if (e.key.toLowerCase() === 'q') setShowEquipment(false);
+    };
+
+    if (inventoryVisible) {
+      window.addEventListener('keyup', handler);
+    }
+
+    return () => window.removeEventListener('keyup', handler);
+  }, [inventoryVisible]);
+
   return (
     <>
       <Fade in={inventoryVisible}>
         <div className="inventory-wrapper">
-          <EquipmentInventory />
+          <InventoryTabs showEquipment={showEquipment} setShowEquipment={setShowEquipment} />
+          <Fade in={showEquipment}>
+            <EquipmentInventory />
+          </Fade>
           <LeftInventory />
           <Tooltip />
           <InventoryContext />

--- a/ox_inventory-custom/web/src/index.scss
+++ b/ox_inventory-custom/web/src/index.scss
@@ -127,6 +127,34 @@ button:active {
   height: 100%;
   gap: 20px;
   z-index: 9999;
+  position: relative;
+}
+
+.inventory-tabs {
+  position: absolute;
+  top: 40px;
+  left: 40px;
+  display: flex;
+  gap: 10px;
+  z-index: 10000;
+
+  .tab-btn {
+    padding: 6px 12px;
+    border-radius: $mainRadius;
+    background: rgba(24, 24, 24, 0.3);
+    border: 0.1px solid #2d2f3a;
+    color: #fff;
+    font-family: $mainFont;
+    font-size: 0.9rem;
+    cursor: pointer;
+    user-select: none;
+
+    &.active,
+    &:hover {
+      background: $primaryBG;
+      border-color: $primary;
+    }
+  }
 }
 
 .pockets-title {
@@ -817,6 +845,34 @@ button:active {
   .inventory-wrapper {
     gap: 40px;
     z-index: 9999;
+    position: relative;
+  }
+
+  .inventory-tabs {
+    position: absolute;
+    top: 80px;
+    left: 80px;
+    display: flex;
+    gap: 10px;
+    z-index: 10000;
+
+    .tab-btn {
+      padding: 10px 18px;
+      border-radius: $mainRadius4K;
+      background: rgba(24, 24, 24, 0.3);
+      border: 0.1px solid #2d2f3a;
+      color: #fff;
+      font-family: $mainFont;
+      font-size: 1.2rem;
+      cursor: pointer;
+      user-select: none;
+
+      &.active,
+      &:hover {
+        background: $primaryBG;
+        border-color: $primary;
+      }
+    }
   }
 
   .equipment-inventory {


### PR DESCRIPTION
## Summary
- add `InventoryTabs` usage and keyboard handlers to toggle equipment menu
- style new `inventory-tabs` buttons for 1080p and 4k resolutions
- highlight active tab in purple and move tabs to the left

## Testing
- `npm install` in `ox_inventory-custom/web`
- `npm run build` in `ox_inventory-custom/web`


------
https://chatgpt.com/codex/tasks/task_e_6865677801148325867474a0145d44a8