### PR TITLE
Add equipment toggle UI

### DIFF
--- a/ox_inventory-custom/web/src/components/inventory/InventoryGrid.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/InventoryGrid.tsx
@@ -10,9 +10,18 @@ const PAGE_SIZE = 24;
 interface InventoryGridProps {
   inventory: Inventory;
   showSlotNumbers?: boolean;
+  collapsible?: boolean;
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
 }
 
-const InventoryGrid: React.FC<InventoryGridProps> = ({ inventory, showSlotNumbers = true }) => {
+const InventoryGrid: React.FC<InventoryGridProps> = ({
+  inventory,
+  showSlotNumbers = true,
+  collapsible = false,
+  collapsed = false,
+  onToggleCollapse,
+}) => {
   const weight = useMemo(
     () => (inventory.maxWeight !== undefined ? Math.floor(getTotalWeight(inventory.items) * 1000) / 1000 : 0),
     [inventory.maxWeight, inventory.items]
@@ -28,12 +37,21 @@ const InventoryGrid: React.FC<InventoryGridProps> = ({ inventory, showSlotNumber
               <p>
                 <span className="weight-icon">⚖</span>
                 {weight / 1000}/{inventory.maxWeight / 1000}kg
+                {collapsible && (
+                  <button
+                    type="button"
+                    className="collapse-toggle"
+                    onClick={onToggleCollapse}
+                  >
+                    {collapsed ? '▲' : '▼'}
+                  </button>
+                )}
               </p>
             )}
           </div>
           <WeightBar percent={inventory.maxWeight ? (weight / inventory.maxWeight) * 100 : 0} />
         </div>
-        <div className="inventory-grid-container">
+        <div className={`inventory-grid-container ${collapsed ? 'collapsed' : ''}`}>
           {inventory.items.slice(0, PAGE_SIZE).map((item) => (
             <InventorySlot
               key={`${inventory.type}-${inventory.id}-${item.slot}`}

--- a/ox_inventory-custom/web/src/components/inventory/InventoryTabs.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/InventoryTabs.tsx
@@ -8,18 +8,20 @@ interface Props {
 const InventoryTabs: React.FC<Props> = ({ showEquipment, setShowEquipment }) => {
   return (
     <div className="inventory-tabs">
-      <div
+      <button
+        type="button"
         className={`tab-btn ${!showEquipment ? 'active' : ''}`}
         onClick={() => setShowEquipment(false)}
       >
         Q Inventory
-      </div>
-      <div
+      </button>
+      <button
+        type="button"
         className={`tab-btn ${showEquipment ? 'active' : ''}`}
         onClick={() => setShowEquipment(true)}
       >
         E Equipment
-      </div>
+      </button>
     </div>
   );
 };

--- a/ox_inventory-custom/web/src/components/inventory/LeftInventory.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/LeftInventory.tsx
@@ -1,14 +1,22 @@
+import { useState } from 'react';
 import InventoryGrid from './InventoryGrid';
 import { useAppSelector } from '../../store';
 import { selectPocketsInventory } from '../../store/inventory';
 
 const LeftInventory: React.FC = () => {
   const leftInventory = useAppSelector(selectPocketsInventory);
+  const [collapsed, setCollapsed] = useState(false);
 
   return (
     <div className="left-inventory">
       <h2 className="pockets-title">Pockets</h2>
-      <InventoryGrid inventory={leftInventory} showSlotNumbers={false} />
+      <InventoryGrid
+        inventory={leftInventory}
+        showSlotNumbers={false}
+        collapsible
+        collapsed={collapsed}
+        onToggleCollapse={() => setCollapsed(!collapsed)}
+      />
     </div>
   );
 };

--- a/ox_inventory-custom/web/src/components/inventory/index.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import useNuiEvent from '../../hooks/useNuiEvent';
 import InventoryHotbar from './InventoryHotbar';
 import { useAppDispatch } from '../../store';
@@ -7,6 +7,7 @@ import { useExitListener } from '../../hooks/useExitListener';
 import type { Inventory as InventoryProps } from '../../typings';
 import EquipmentInventory from './EquipmentInventory';
 import LeftInventory from './LeftInventory';
+import InventoryTabs from './InventoryTabs';
 import Tooltip from '../utils/Tooltip';
 import { closeTooltip } from '../../store/tooltip';
 import InventoryContext from './InventoryContext';
@@ -15,6 +16,7 @@ import Fade from '../utils/transitions/Fade';
 
 const Inventory: React.FC = () => {
   const [inventoryVisible, setInventoryVisible] = useState(false);
+  const [showEquipment, setShowEquipment] = useState(true);
   const dispatch = useAppDispatch();
 
   useNuiEvent<boolean>('setInventoryVisible', setInventoryVisible);
@@ -39,11 +41,27 @@ const Inventory: React.FC = () => {
     dispatch(setAdditionalMetadata(data));
   });
 
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() === 'e') setShowEquipment(true);
+      if (e.key.toLowerCase() === 'q') setShowEquipment(false);
+    };
+
+    if (inventoryVisible) {
+      window.addEventListener('keyup', handler);
+    }
+
+    return () => window.removeEventListener('keyup', handler);
+  }, [inventoryVisible]);
+
   return (
     <>
       <Fade in={inventoryVisible}>
         <div className="inventory-wrapper">
-          <EquipmentInventory />
+          <InventoryTabs showEquipment={showEquipment} setShowEquipment={setShowEquipment} />
+          <Fade in={showEquipment}>
+            <EquipmentInventory />
+          </Fade>
           <LeftInventory />
           <Tooltip />
           <InventoryContext />

--- a/ox_inventory-custom/web/src/index.scss
+++ b/ox_inventory-custom/web/src/index.scss
@@ -127,6 +127,37 @@ button:active {
   height: 100%;
   gap: 20px;
   z-index: 9999;
+  position: relative;
+}
+
+.inventory-tabs {
+  position: absolute;
+  top: 100px;
+  left: 120px;
+  display: flex;
+  gap: 10px;
+  z-index: 10000;
+  transform: perspective(1000px) rotateY(10deg);
+  transform-origin: left center;
+
+  .tab-btn {
+    padding: 8px 14px;
+    border-radius: $mainRadius;
+    background: rgba(24, 24, 24, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: #fff;
+    font-family: $mainFont;
+    font-size: 0.9rem;
+    cursor: pointer;
+    user-select: none;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+
+    &.active,
+    &:hover {
+      background: $primaryBG;
+      border-color: $primary;
+    }
+  }
 }
 
 .pockets-title {
@@ -496,6 +527,15 @@ button:active {
   .weight-icon {
     padding-right: 4px;
   }
+
+  .collapse-toggle {
+    margin-left: 6px;
+    background: none;
+    border: none;
+    color: #fff;
+    cursor: pointer;
+    font-size: 1rem;
+  }
 }
 
 .inventory-grid-container {
@@ -508,6 +548,13 @@ button:active {
   padding-top: 7px;
   padding-left: 7px;
   padding-right: 7px;
+  transition: height 0.3s ease;
+
+  &.collapsed {
+    height: 0;
+    overflow: hidden;
+    padding-top: 0;
+  }
 }
 
 // item slot
@@ -817,6 +864,37 @@ button:active {
   .inventory-wrapper {
     gap: 40px;
     z-index: 9999;
+    position: relative;
+  }
+
+  .inventory-tabs {
+    position: absolute;
+    top: 160px;
+    left: 200px;
+    display: flex;
+    gap: 10px;
+    z-index: 10000;
+    transform: perspective(1000px) rotateY(10deg);
+    transform-origin: left center;
+
+    .tab-btn {
+      padding: 14px 24px;
+      border-radius: $mainRadius4K;
+      background: rgba(24, 24, 24, 0.3);
+      border: 1px solid rgba(255, 255, 255, 0.15);
+      color: #fff;
+      font-family: $mainFont;
+      font-size: 1.2rem;
+      cursor: pointer;
+      user-select: none;
+      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+
+      &.active,
+      &:hover {
+        background: $primaryBG;
+        border-color: $primary;
+      }
+    }
   }
 
   .equipment-inventory {
@@ -1044,6 +1122,15 @@ button:active {
     .weight-icon {
       padding-right: 8px;
     }
+
+    .collapse-toggle {
+      margin-left: 10px;
+      background: none;
+      border: none;
+      color: #fff;
+      cursor: pointer;
+      font-size: 2rem;
+    }
   }
 
   .inventory-grid-container {
@@ -1055,6 +1142,13 @@ button:active {
     overflow-y: scroll;
     padding-left: 7px;
     padding-right: 7px;
+    transition: height 0.3s ease;
+
+    &.collapsed {
+      height: 0;
+      overflow: hidden;
+      padding-top: 0;
+    }
   }
 
   .item-slot-wrapper {


### PR DESCRIPTION
## Summary
- style inventory toggle buttons and tilt them toward the user
- replace tab divs with buttons for better accessibility
- adjust tabs positioning further from the edges for 1080p and 4K
- add collapsible Pockets grid with toggle arrow

## Testing
- `npm install` in `ox_inventory-custom/web`
- `npm run build` in `ox_inventory-custom/web`


------
https://chatgpt.com/codex/tasks/task_e_6865677801148325867474a0145d44a8