### PR TITLE
Improve cart UI and double-click handling

### DIFF
--- a/ox_inventory-custom/web/src/cart.scss
+++ b/ox_inventory-custom/web/src/cart.scss
@@ -1,0 +1,76 @@
+.shop-inventory {
+  position: absolute;
+  left: 4%;
+  top: 50%;
+  transform: translateY(-50%) perspective(1000px) rotateY(10deg);
+  transform-origin: left center;
+  background: rgba(24, 24, 24, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 0 24px rgba(0, 0, 0, 0.6);
+  border-radius: 18px;
+  padding: 10px;
+}
+
+.shopping-cart {
+  margin-top: 10px;
+  background: rgba(24, 24, 24, 0.3);
+  padding: 8px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  max-height: 200px;
+  overflow-y: auto;
+}
+.cart-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8rem;
+}
+.cart-table th, .cart-table td {
+  border-bottom: 1px solid #555;
+  padding: 4px;
+  text-align: center;
+}
+.cart-table input {
+  width: 40px;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid #555;
+  color: #fff;
+  text-align: center;
+  margin: 0 4px;
+  border-radius: 4px;
+}
+.qty-cell button {
+  margin: 0 4px;
+}
+.cart-summary {
+  margin-top: 8px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.cart-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 4px;
+  margin-top: 4px;
+}
+.pay-btn {
+  display: flex;
+  padding: 8px 14px;
+  border-radius: $mainRadius;
+  background: rgba(24, 24, 24, 0.3);
+  border: 0.5px solid rgba(247, 247, 247, 0.6);
+  color: #fff;
+  font-family: $mainFont;
+  font-size: 0.9rem;
+  cursor: pointer;
+  user-select: none;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    background: $primaryBG;
+    border-color: $primary;
+  }
+}

--- a/ox_inventory-custom/web/src/components/cart/ShopInventory.tsx
+++ b/ox_inventory-custom/web/src/components/cart/ShopInventory.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import InventoryGrid from '../inventory/InventoryGrid';
+import { useAppSelector } from '../../store';
+import { selectRightInventory } from '../../store/inventory';
+import ShoppingCart from './ShoppingCart';
+
+const ShopInventory: React.FC = () => {
+  const shopInventory = useAppSelector(selectRightInventory);
+
+  return (
+    <div className="shop-inventory">
+      <h2 className="pockets-title">{shopInventory.label}</h2>
+      <InventoryGrid inventory={shopInventory} showSlotNumbers={false} showWeightBar={false} />
+      <ShoppingCart />
+    </div>
+  );
+};
+
+export default ShopInventory;

--- a/ox_inventory-custom/web/src/components/cart/ShoppingCart.tsx
+++ b/ox_inventory-custom/web/src/components/cart/ShoppingCart.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { useDrop } from 'react-dnd';
+import { useAppDispatch, useAppSelector } from '../../store';
+import { DragSource } from '../../typings';
+import { removeItem, updateQuantity, clear, addItem } from '../../store/cart';
+import { getItemUrl } from '../../helpers';
+import { Items } from '../../store/items';
+import bankIcon from '../../../images/card_bank.png?url';
+import cashIcon from '../../../images/money.png?url';
+
+const ShoppingCart: React.FC = () => {
+  const dispatch = useAppDispatch();
+  const items = useAppSelector((state) => state.cart.items);
+  const shop = useAppSelector((state) => state.inventory.rightInventory);
+  const [, drop] = useDrop<DragSource>(() => ({
+    accept: 'SLOT',
+    drop: (source) => {
+      const slot = source.item.slot;
+      const shopItem = shop.items[slot - 1];
+      if (shopItem) {
+        dispatch(addItem({ slot, item: shopItem as any, quantity: 1 }));
+      }
+    },
+  }));
+
+  const total = items.reduce((acc, item) => acc + item.item.price! * item.quantity, 0);
+
+  const handlePay = (method: 'bank' | 'cash') => {
+    // Placeholder for payment logic
+    console.log('Pay', method, items);
+    dispatch(clear());
+  };
+
+  return (
+    <div className="shopping-cart" ref={drop}>
+      <h3 className="pockets-title">Shopping Cart</h3>
+      <table className="cart-table">
+        <tbody>
+          {items.map((entry) => (
+            <tr key={entry.slot}>
+              <td>
+                <img src={getItemUrl(entry.item)} alt="" width={32} />
+              </td>
+              <td className="cart-name">
+                {entry.item.metadata?.label
+                  ? entry.item.metadata.label
+                  : Items[entry.item.name]?.label || entry.item.name}
+              </td>
+              <td className="cart-type">{entry.item.metadata?.quality || 'COMMON'}</td>
+              <td className="qty-cell">
+                <button onClick={() => dispatch(updateQuantity({ slot: entry.slot, quantity: Math.max(1, entry.quantity - 1) }))}>-</button>
+                <input
+                  type="number"
+                  min={1}
+                  value={entry.quantity}
+                  onChange={(e) =>
+                    dispatch(updateQuantity({
+                      slot: entry.slot,
+                      quantity: Math.max(1, Number(e.target.value)),
+                    }))
+                  }
+                />
+                <button onClick={() => dispatch(updateQuantity({ slot: entry.slot, quantity: entry.quantity + 1 }))}>+</button>
+              </td>
+              <td className="unit-price">${entry.item.price}</td>
+              <td className="total-price">${entry.item.price! * entry.quantity}</td>
+              <td>
+                <button onClick={() => dispatch(removeItem(entry.slot))}>🗑️</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="cart-summary">
+        <span className="total-label">Total Cost:</span>
+        <span className="total-value">${total}</span>
+      </div>
+      <div className="cart-actions">
+        <button className="pay-btn" onClick={() => handlePay('bank')}>
+          <img src={bankIcon} alt="pay bank" width={20} />
+        </button>
+        <button className="pay-btn" onClick={() => handlePay('cash')}>
+          <img src={cashIcon} alt="pay cash" width={20} />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ShoppingCart;

--- a/ox_inventory-custom/web/src/components/inventory/InventoryGrid.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/InventoryGrid.tsx
@@ -13,6 +13,7 @@ interface InventoryGridProps {
   collapsible?: boolean;
   collapsed?: boolean;
   onToggleCollapse?: () => void;
+  showWeightBar?: boolean;
 }
 
 const InventoryGrid: React.FC<InventoryGridProps> = ({
@@ -21,6 +22,7 @@ const InventoryGrid: React.FC<InventoryGridProps> = ({
   collapsible = false,
   collapsed = false,
   onToggleCollapse,
+  showWeightBar = true,
 }) => {
   const isGround = inventory.type === 'drop' || inventory.type === 'newdrop';
   const weight = useMemo(
@@ -34,22 +36,24 @@ const InventoryGrid: React.FC<InventoryGridProps> = ({
         <div>
           <div className={`inventory-grid-header-wrapper ${isGround ? 'ground-header' : ''}`}>
             {!isGround && <p>{inventory.label}</p>}
-            <p className="weight-info">
-              <span className="weight-icon">⚖</span>
-              {weight / 1000}
-              {!isGround && inventory.maxWeight ? `/${inventory.maxWeight / 1000}kg` : 'kg'}
-              {collapsible && (
-                <button
-                  type="button"
-                  className="collapse-toggle"
-                  onClick={onToggleCollapse}
-                >
-                  {collapsed ? '▲' : '▼'}
-                </button>
-              )}
-            </p>
+            {showWeightBar && (
+              <p className="weight-info">
+                <span className="weight-icon">⚖</span>
+                {weight / 1000}
+                {!isGround && inventory.maxWeight ? `/${inventory.maxWeight / 1000}kg` : 'kg'}
+                {collapsible && (
+                  <button
+                    type="button"
+                    className="collapse-toggle"
+                    onClick={onToggleCollapse}
+                  >
+                    {collapsed ? '▲' : '▼'}
+                  </button>
+                )}
+              </p>
+            )}
           </div>
-          {!isGround && (
+          {!isGround && showWeightBar && (
             <WeightBar percent={inventory.maxWeight ? (weight / inventory.maxWeight) * 100 : 0} />
           )}
         </div>

--- a/ox_inventory-custom/web/src/components/inventory/InventorySlot.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/InventorySlot.tsx
@@ -13,6 +13,7 @@ import { Locale } from '../../store/locale';
 import { onCraft } from '../../dnd/onCraft';
 import { validateMove } from '../../thunks/validateItems';
 import { selectLeftInventory } from '../../store/inventory';
+import { addItem } from '../../store/cart';
 import useNuiEvent from '../../hooks/useNuiEvent';
 import { ItemsPayload } from '../../reducers/refreshSlots';
 import { closeTooltip, openTooltip } from '../../store/tooltip';
@@ -70,6 +71,7 @@ const InventorySlot: React.ForwardRefRenderFunction<HTMLDivElement, SlotProps> =
                 slot: item.slot,
               },
               image: item?.name && `url(${getItemUrl(item) || 'none'}`,
+              itemData: inventoryType === InventoryType.SHOP ? item : undefined,
             }
           : null,
       canDrag,
@@ -133,6 +135,10 @@ const InventorySlot: React.ForwardRefRenderFunction<HTMLDivElement, SlotProps> =
 
   const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
     dispatch(closeTooltip());
+    if (event.detail === 2 && inventoryType === 'shop' && isSlotWithItem(item)) {
+      dispatch(addItem({ slot: item.slot, item: item as SlotWithItem, quantity: 1 }));
+      return;
+    }
     if (timerRef.current) clearTimeout(timerRef.current);
     if (event.ctrlKey && isSlotWithItem(item) && inventoryType !== 'shop' && inventoryType !== 'crafting') {
       if (inventoryType === 'newdrop' || inventoryType === 'drop') {

--- a/ox_inventory-custom/web/src/components/inventory/SplitDialog.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/SplitDialog.tsx
@@ -22,7 +22,7 @@ const SplitDialog: React.FC<Props> = ({ visible, onClose, item }) => {
   const max = item?.count ? Math.max(1, item.count - 1) : 1;
   const [qty, setQty] = useState(1);
   const { refs, context } = useFloating({ open: visible, onOpenChange: onClose });
-  const dismiss = useDismiss(context, { outsidePressEvent: 'pointerdown' });
+  const dismiss = useDismiss(context, { outsidePressEvent: 'mousedown' });
   const { isMounted, styles } = useTransitionStyles(context);
   const { getFloatingProps } = useInteractions([dismiss]);
 

--- a/ox_inventory-custom/web/src/components/inventory/index.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/index.tsx
@@ -14,11 +14,15 @@ import { closeTooltip } from '../../store/tooltip';
 import InventoryContext from './InventoryContext';
 import { closeContextMenu } from '../../store/contextMenu';
 import Fade from '../utils/transitions/Fade';
+import { useAppSelector } from '../../store';
+import { selectRightInventory } from '../../store/inventory';
+import ShopInventory from '../cart/ShopInventory';
 
 const Inventory: React.FC = () => {
   const [inventoryVisible, setInventoryVisible] = useState(false);
   const [showEquipment, setShowEquipment] = useState(true);
   const dispatch = useAppDispatch();
+  const rightInventory = useAppSelector(selectRightInventory);
 
   useNuiEvent<boolean>('setInventoryVisible', setInventoryVisible);
   useNuiEvent<false>('closeInventory', () => {
@@ -64,7 +68,7 @@ const Inventory: React.FC = () => {
             <EquipmentInventory />
           </Fade>
           <Fade in={!showEquipment}>
-            <GroundInventory />
+            {rightInventory.type === 'shop' ? <ShopInventory /> : <GroundInventory />}
           </Fade>
           <LeftInventory />
           <Tooltip />

--- a/ox_inventory-custom/web/src/dnd/onAddToCart.ts
+++ b/ox_inventory-custom/web/src/dnd/onAddToCart.ts
@@ -1,0 +1,8 @@
+import { store } from '../store';
+import { DragSource } from '../typings';
+import { addItem } from '../store/cart';
+import { SlotWithItem } from '../typings';
+
+export const onAddToCart = (source: DragSource, item: SlotWithItem) => {
+  store.dispatch(addItem({ slot: item.slot, item, quantity: 1 }));
+};

--- a/ox_inventory-custom/web/src/index.scss
+++ b/ox_inventory-custom/web/src/index.scss
@@ -1,6 +1,7 @@
 @import './vars';
 @import './slots';
 @import './custom';
+@import './cart';
 
 body {
   margin: 0;

--- a/ox_inventory-custom/web/src/store/cart.ts
+++ b/ox_inventory-custom/web/src/store/cart.ts
@@ -1,0 +1,44 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { SlotWithItem } from '../typings';
+
+export interface CartItem {
+  slot: number;
+  item: SlotWithItem;
+  quantity: number;
+}
+
+interface CartState {
+  items: CartItem[];
+}
+
+const initialState: CartState = {
+  items: [],
+};
+
+export const cartSlice = createSlice({
+  name: 'cart',
+  initialState,
+  reducers: {
+    addItem: (state, action: PayloadAction<CartItem>) => {
+      const idx = state.items.findIndex((it) => it.slot === action.payload.slot);
+      if (idx >= 0) {
+        state.items[idx].quantity += action.payload.quantity;
+      } else {
+        state.items.push(action.payload);
+      }
+    },
+    removeItem: (state, action: PayloadAction<number>) => {
+      state.items = state.items.filter((it) => it.slot !== action.payload);
+    },
+    updateQuantity: (state, action: PayloadAction<{ slot: number; quantity: number }>) => {
+      const item = state.items.find((it) => it.slot === action.payload.slot);
+      if (item) item.quantity = action.payload.quantity;
+    },
+    clear: (state) => {
+      state.items = [];
+    },
+  },
+});
+
+export const { addItem, removeItem, updateQuantity, clear } = cartSlice.actions;
+export default cartSlice.reducer;

--- a/ox_inventory-custom/web/src/store/index.ts
+++ b/ox_inventory-custom/web/src/store/index.ts
@@ -3,12 +3,14 @@ import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import inventoryReducer from './inventory';
 import tooltipReducer from './tooltip';
 import contextMenuReducer from './contextMenu';
+import cartReducer from './cart';
 
 export const store = configureStore({
   reducer: {
     inventory: inventoryReducer,
     tooltip: tooltipReducer,
     contextMenu: contextMenuReducer,
+    cart: cartReducer,
   },
 });
 

--- a/ox_inventory-custom/web/src/typings/cart.ts
+++ b/ox_inventory-custom/web/src/typings/cart.ts
@@ -1,0 +1,7 @@
+import { SlotWithItem } from './slot';
+
+export interface CartItem {
+  slot: number;
+  item: SlotWithItem;
+  quantity: number;
+}

--- a/ox_inventory-custom/web/src/typings/dnd.ts
+++ b/ox_inventory-custom/web/src/typings/dnd.ts
@@ -5,6 +5,7 @@ export type DragSource = {
   item: Pick<SlotWithItem, 'slot' | 'name'>;
   inventory: Inventory['type'];
   image?: string;
+  itemData?: SlotWithItem;
 };
 
 export type DropTarget = {

--- a/ox_inventory-custom/web/src/typings/index.ts
+++ b/ox_inventory-custom/web/src/typings/index.ts
@@ -3,3 +3,4 @@ export * from './inventory';
 export * from './item';
 export * from './slot';
 export * from './dnd';
+export * from './cart';


### PR DESCRIPTION
## Summary
- tweak cart appearance and buttons to match inventory style
- support editing quantities and remove table headers
- allow double-clicking shop items to add to cart

## Testing
- `pnpm install`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6865c04b65288325a02154d177606fb6