### PR TITLE
Improve shop purchases with bank support

### DIFF
--- a/ox_inventory-custom/client.lua
+++ b/ox_inventory-custom/client.lua
@@ -1881,6 +1881,16 @@ RegisterNUICallback('buyItem', function(data, cb)
 	cb(response)
 end)
 
+RegisterNUICallback('buyCart', function(data, cb)
+        local success, message = lib.callback.await('ox_inventory:buyCart', 100, data)
+
+        if not success and message then
+                lib.notify(message)
+        end
+
+        cb(success or false)
+end)
+
 RegisterNUICallback('craftItem', function(data, cb)
 	cb(true)
 

--- a/ox_inventory-custom/data/items.lua
+++ b/ox_inventory-custom/data/items.lua
@@ -188,7 +188,6 @@ return {
                         notification = 'You used your phone'
                 }
         },
-
         ['money'] = {
                 label = 'Money',
                 metadata = { quality = 'Common' },
@@ -197,7 +196,6 @@ return {
                         notification = 'You checked your money'
                 }
         },
-
         ['mustard'] = {
                 label = 'Mustard',
                 weight = 500,

--- a/ox_inventory-custom/modules/bridge/qb/server.lua
+++ b/ox_inventory-custom/modules/bridge/qb/server.lua
@@ -102,7 +102,7 @@ function server.UseItem(source, itemName, data)
 end
 
 AddEventHandler('QBCore:Server:OnMoneyChange', function(src, account, amount, changeType)
-    if account ~= "cash" then return end
+    if account ~= 'cash' then return end
 
     local item = Inventory.GetItem(src, 'money', nil, false)
 

--- a/ox_inventory-custom/modules/inventory/server.lua
+++ b/ox_inventory-custom/modules/inventory/server.lua
@@ -2191,6 +2191,24 @@ end
 exports('GetEmptySlot', Inventory.GetEmptySlot)
 
 ---@param inv inventory
+---@return integer?
+function Inventory.GetEmptyPocketSlot(inv)
+    local inventory = Inventory(inv)
+
+    if not inventory then return end
+
+    local items = inventory.items
+
+    for i = 10, inventory.slots do
+        if not items[i] then
+            return i
+        end
+    end
+end
+
+exports('GetEmptyPocketSlot', Inventory.GetEmptyPocketSlot)
+
+---@param inv inventory
 ---@param itemName string
 ---@param metadata any
 function Inventory.GetSlotForItem(inv, itemName, metadata)

--- a/ox_inventory-custom/modules/shops/server.lua
+++ b/ox_inventory-custom/modules/shops/server.lua
@@ -115,7 +115,130 @@ end
 ---@param shopType string
 ---@param shopDetails OxShop
 exports('RegisterShop', function(shopType, shopDetails)
-	registerShopType(shopType, shopDetails)
+       registerShopType(shopType, shopDetails)
+end)
+
+-- Forward declarations for affordability helpers so they are available to
+-- callbacks defined below.
+local canAffordItem, removeCurrency
+
+---Check if the player has enough currency for a purchase.
+---@param inv inventory
+---@param currency string
+---@param price number
+---@return true | table
+function canAffordItem(inv, currency, price)
+       if currency == 'bank' then
+               local player = server.GetPlayerFromId(inv.id)
+               local canAfford = player and player.Functions.GetMoney('bank') >= price
+               return canAfford or {
+                       type = 'error',
+                       description = locale('cannot_afford', ('%s%s'):format(locale('$'), math.groupdigits(price)))
+               }
+       end
+
+       local canAfford = price >= 0 and Inventory.GetItemCount(inv, currency) >= price
+
+       return canAfford or {
+               type = 'error',
+               description = locale('cannot_afford', ('%s%s'):format((currency == 'money' and locale('$') or math.groupdigits(price)), (currency == 'money' and math.groupdigits(price) or ' '..Items(currency).label)))
+       }
+end
+
+---Remove currency from the player's inventory or bank account.
+---@param inv inventory
+---@param currency string
+---@param price number
+function removeCurrency(inv, currency, price)
+       if currency == 'bank' then
+               local player = server.GetPlayerFromId(inv.id)
+               if player then
+                       player.Functions.RemoveMoney('bank', price, 'ox_inventory_shop')
+               end
+       else
+               Inventory.RemoveItem(inv, currency, price)
+       end
+end
+
+lib.callback.register('ox_inventory:buyCart', function(source, data)
+       local playerInv = Inventory(source)
+       if not playerInv or not playerInv.currentShop then return end
+
+       local shopType, shopId = playerInv.currentShop:match('^(.-) (%d+)$')
+       if not shopType then shopType = playerInv.currentShop end
+       if shopId then shopId = tonumber(shopId) end
+
+       local shop = shopId and Shops[shopType][shopId] or Shops[shopType]
+       local items = data.items or {}
+       local currency = data.currency or 'money'
+
+       local additions = {}
+       local totalPrice = 0
+       local itemNames = {}
+
+       for _, entry in ipairs(items) do
+               local fromData = shop.items[entry.fromSlot]
+               if fromData then
+                       local count = entry.count or 1
+                       if fromData.count and fromData.count < count then
+                               count = fromData.count
+                       end
+
+                       if count < 1 then goto continue end
+
+                       local fromItem = Items(fromData.name)
+                       local metadata, realCount = Items.Metadata(playerInv, fromItem, fromData.metadata and table.clone(fromData.metadata) or {}, count)
+                       local price = realCount * fromData.price
+
+                       local targetSlot = Inventory.GetSlotForItem(playerInv, fromItem.name, metadata) or Inventory.GetEmptyPocketSlot(playerInv)
+                       local toData = targetSlot and playerInv.items[targetSlot]
+                       local toItem = toData and Items(toData.name)
+
+                       if targetSlot and (toData == nil or (fromItem.name == toItem?.name and fromItem.stack and table.matches(toData.metadata, metadata))) then
+                               local newWeight = playerInv.weight + (fromItem.weight + (metadata?.weight or 0)) * realCount
+                               if newWeight > playerInv.maxWeight then
+                                       return false, false, { type = 'error', description = locale('cannot_carry') }
+                               end
+
+                               table.insert(additions, {slot = targetSlot, item = fromItem, count = realCount, metadata = metadata, price = price, fromSlot = entry.fromSlot})
+                               totalPrice = totalPrice + price
+                               table.insert(itemNames, metadata?.label or fromItem.label)
+                       else
+                               return false, false, { type = 'error', description = locale('unable_stack_items') }
+                       end
+               end
+               ::continue::
+       end
+
+       if #additions == 0 then return false end
+
+       local afford = canAffordItem(playerInv, currency, totalPrice)
+       if afford ~= true then return false, false, afford end
+
+       for _, info in ipairs(additions) do
+               Inventory.SetSlot(playerInv, info.item, info.count, info.metadata, info.slot)
+               playerInv.weight = playerInv.weight + (info.item.weight + (info.metadata?.weight or 0)) * info.count
+
+               local shopItem = shop.items[info.fromSlot]
+               if shopItem and shopItem.count then
+                       shopItem.count = shopItem.count - info.count
+               end
+       end
+
+       removeCurrency(playerInv, currency, totalPrice)
+
+       if currency == 'bank' then
+               local player = server.GetPlayerFromId(playerInv.id)
+               if player then
+                       local receiverId = ('shop_%s'):format(shopType)
+                       TriggerEvent('okokBanking:AddNewTransaction', shop.label, receiverId, GetPlayerName(source), player.PlayerData.identifier, totalPrice, ('Zakup w sklepie: %s'):format(table.concat(itemNames, ', ')))
+                       TriggerClientEvent('ox_lib:notify', source, { type = 'success', description = ('✅ Zakupiono przedmiot(y) za %s z konta bankowego.'):format(totalPrice) })
+               end
+       end
+
+       if server.syncInventory then server.syncInventory(playerInv) end
+
+       return true
 end)
 
 lib.callback.register('ox_inventory:openShop', function(source, data)
@@ -153,19 +276,6 @@ lib.callback.register('ox_inventory:openShop', function(source, data)
 	return { label = left.label, type = left.type, slots = left.slots, weight = left.weight, maxWeight = left.maxWeight }, shop
 end)
 
-local function canAffordItem(inv, currency, price)
-	local canAfford = price >= 0 and Inventory.GetItemCount(inv, currency) >= price
-
-	return canAfford or {
-		type = 'error',
-		description = locale('cannot_afford', ('%s%s'):format((currency == 'money' and locale('$') or math.groupdigits(price)), (currency == 'money' and math.groupdigits(price) or ' '..Items(currency).label)))
-	}
-end
-
-local function removeCurrency(inv, currency, price)
-	Inventory.RemoveItem(inv, currency, price)
-end
-
 local TriggerEventHooks = require 'modules.hooks.server'
 
 local function isRequiredGrade(grade, rank)
@@ -195,9 +305,8 @@ lib.callback.register('ox_inventory:buyItem', function(source, data)
 
 		if shopId then shopId = tonumber(shopId) end
 
-		local shop = shopId and Shops[shopType][shopId] or Shops[shopType]
-		local fromData = shop.items[data.fromSlot]
-		local toData = playerInv.items[data.toSlot]
+                local shop = shopId and Shops[shopType][shopId] or Shops[shopType]
+                local fromData = shop.items[data.fromSlot]
 
 		if fromData then
 			if fromData.count then
@@ -222,15 +331,17 @@ lib.callback.register('ox_inventory:buyItem', function(source, data)
                         local currency = data.currency or fromData.currency or 'money'
 			local fromItem = Items(fromData.name)
 
-			local result = fromItem.cb and fromItem.cb('buying', fromItem, playerInv, data.fromSlot, shop)
-			if result == false then return false end
+                        local result = fromItem.cb and fromItem.cb('buying', fromItem, playerInv, data.fromSlot, shop)
+                        if result == false then return false end
 
-			local toItem = toData and Items(toData.name)
+                        local metadata, count = Items.Metadata(playerInv, fromItem, fromData.metadata and table.clone(fromData.metadata) or {}, data.count)
+                        local price = count * fromData.price
 
-			local metadata, count = Items.Metadata(playerInv, fromItem, fromData.metadata and table.clone(fromData.metadata) or {}, data.count)
-			local price = count * fromData.price
+                       local targetSlot = Inventory.GetSlotForItem(playerInv, fromItem.name, metadata) or Inventory.GetEmptyPocketSlot(playerInv)
+                        local toData = targetSlot and playerInv.items[targetSlot]
+                        local toItem = toData and Items(toData.name)
 
-			if toData == nil or (fromItem.name == toItem?.name and fromItem.stack and table.matches(toData.metadata, metadata)) then
+                        if targetSlot and (toData == nil or (fromItem.name == toItem?.name and fromItem.stack and table.matches(toData.metadata, metadata))) then
 				local newWeight = playerInv.weight + (fromItem.weight + (metadata?.weight or 0)) * count
 
 				if newWeight > playerInv.maxWeight then
@@ -243,24 +354,33 @@ lib.callback.register('ox_inventory:buyItem', function(source, data)
 					return false, false, canAfford
 				end
 
-				if not TriggerEventHooks('buyItem', {
-					source = source,
-					shopType = shopType,
-					shopId = shopId,
-					toInventory = playerInv.id,
-					toSlot = data.toSlot,
-					fromSlot = fromData,
-					itemName = fromData.name,
-					metadata = metadata,
-					count = count,
-					price = fromData.price,
-					totalPrice = price,
-					currency = currency,
-				}) then return false end
+                                if not TriggerEventHooks('buyItem', {
+                                        source = source,
+                                        shopType = shopType,
+                                        shopId = shopId,
+                                        toInventory = playerInv.id,
+                                        toSlot = targetSlot,
+                                        fromSlot = fromData,
+                                        itemName = fromData.name,
+                                        metadata = metadata,
+                                        count = count,
+                                        price = fromData.price,
+                                        totalPrice = price,
+                                        currency = currency,
+                                }) then return false end
 
-				Inventory.SetSlot(playerInv, fromItem, count, metadata, data.toSlot)
-				playerInv.weight = newWeight
-				removeCurrency(playerInv, currency, price)
+                                Inventory.SetSlot(playerInv, fromItem, count, metadata, targetSlot)
+                                playerInv.weight = newWeight
+                                removeCurrency(playerInv, currency, price)
+
+                                if currency == 'bank' then
+                                        local player = server.GetPlayerFromId(playerInv.id)
+                                        if player then
+                                                local receiverId = ('shop_%s'):format(shopType)
+                                                TriggerEvent('okokBanking:AddNewTransaction', shop.label, receiverId, GetPlayerName(source), player.PlayerData.identifier, price, ('Zakup w sklepie: %s'):format(metadata?.label or fromItem.label))
+                                                TriggerClientEvent('ox_lib:notify', source, { type = 'success', description = ('✅ Zakupiono przedmiot za %s z konta bankowego.'):format(price) })
+                                        end
+                                end
 
 				if fromData.count then
 					shop.items[data.fromSlot].count = fromData.count - count
@@ -276,8 +396,8 @@ lib.callback.register('ox_inventory:buyItem', function(source, data)
 					end
 				end
 
-				return true, {data.toSlot, playerInv.items[data.toSlot], shop.items[data.fromSlot].count and shop.items[data.fromSlot], playerInv.weight}, { type = 'success', description = message }
-			end
+                                return true, {targetSlot, playerInv.items[targetSlot], shop.items[data.fromSlot].count and shop.items[data.fromSlot], playerInv.weight}, { type = 'success', description = message }
+                        end
 
 			return false, false, { type = 'error', description = locale('unable_stack_items') }
 		end

--- a/ox_inventory-custom/web/src/components/cart/ShoppingCart.tsx
+++ b/ox_inventory-custom/web/src/components/cart/ShoppingCart.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useDrop } from 'react-dnd';
-import { useAppDispatch, useAppSelector, store } from '../../store';
+import { useAppDispatch, useAppSelector } from '../../store';
 import { DragSource } from '../../typings';
 import {
   removeItem,
@@ -8,9 +8,9 @@ import {
   clear,
   addItem,
 } from '../../store/cart';
-import { getItemUrl, findAvailableSlot, isSlotWithItem } from '../../helpers';
+import { getItemUrl } from '../../helpers';
 import { Items } from '../../store/items';
-import { buyItem } from '../../thunks/buyItem';
+import { buyCart } from '../../thunks/buyCart';
 import bankIcon from '../../../images/card_bank.png?url';
 import cashIcon from '../../../images/money.png?url';
 
@@ -32,31 +32,13 @@ const ShoppingCart: React.FC = () => {
   const total = items.reduce((acc, item) => acc + item.item.price! * item.quantity, 0);
 
   const handlePay = async (method: 'bank' | 'cash') => {
-    for (const entry of items) {
-      if (!isSlotWithItem(entry.item)) continue;
-      const player = store.getState().inventory.leftInventory;
-      const pockets = player.items.slice(9);
-      const data = Items[entry.item.name];
-      const target =
-        findAvailableSlot(entry.item, data!, pockets) ||
-        pockets.find((s) => s.name === undefined);
-
-      if (!target) {
-        console.error('No slot for', entry.item.name);
-        continue;
-      }
-
-      await dispatch(
-        buyItem({
-          fromSlot: entry.slot,
-          fromType: shop.type,
-          toSlot: target.slot,
-          toType: player.type,
-          count: entry.quantity,
-          currency: method === 'bank' ? 'bank' : 'money',
-        })
-      );
-    }
+    if (items.length === 0) return;
+    await dispatch(
+      buyCart({
+        items: items.map((entry) => ({ fromSlot: entry.slot, count: entry.quantity })),
+        currency: method === 'bank' ? 'bank' : 'money',
+      })
+    );
     dispatch(clear());
   };
 

--- a/ox_inventory-custom/web/src/helpers/index.ts
+++ b/ox_inventory-custom/web/src/helpers/index.ts
@@ -88,7 +88,8 @@ export const canStack = (sourceSlot: Slot, targetSlot: Slot) =>
 export const findAvailableSlot = (item: Slot, data: ItemData, items: Slot[]) => {
   if (!data.stack) return items.find((target) => target.name === undefined);
 
-  const stackableSlot = items.find((target) => target.name === item.name && isEqual(target.metadata, item.metadata));
+  const meta = item.metadata ?? data.metadata ?? {};
+  const stackableSlot = items.find((target) => target.name === item.name && isEqual(target.metadata, meta));
 
   return stackableSlot || items.find((target) => target.name === undefined);
 };
@@ -104,8 +105,8 @@ export const getTargetInventory = (
       ? state.leftInventory
       : state.rightInventory
     : sourceType === InventoryType.PLAYER
-    ? state.rightInventory
-    : state.leftInventory,
+      ? state.rightInventory
+      : state.leftInventory,
 });
 
 export const itemDurability = (metadata: any, curTime: number) => {

--- a/ox_inventory-custom/web/src/thunks/buyCart.ts
+++ b/ox_inventory-custom/web/src/thunks/buyCart.ts
@@ -1,0 +1,21 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { fetchNui } from '../utils/fetchNui';
+
+export const buyCart = createAsyncThunk(
+  'inventory/buyCart',
+  async (
+    data: { items: { fromSlot: number; count: number }[]; currency?: string },
+    { rejectWithValue }
+  ) => {
+    try {
+      const response = await fetchNui<boolean>('buyCart', data);
+
+      if (response === false) {
+        return rejectWithValue(response);
+      }
+    } catch (error) {
+      return rejectWithValue(false);
+    }
+  }
+);
+


### PR DESCRIPTION
## Summary
- add `GetEmptyPocketSlot` helper for player inventories
- use the pocket-only slot when buying single items
- implement server-side `buyCart` to process multiple items in one purchase and log bank transactions
- add client and web support for the new cart purchase flow
- fix bank purchase logic by defining helper functions before callbacks

## Testing
- `npm run build` *(fails: Cannot find module '@reduxjs/toolkit')*

------
https://chatgpt.com/codex/tasks/task_e_6866e8a25e5883259b4e3ca8abc9b4d4