### PR TITLE
Add backpack inventory support

### DIFF
--- a/ox_inventory-custom/client.lua
+++ b/ox_inventory-custom/client.lua
@@ -159,7 +159,7 @@ function client.openInventory(inv, data)
         return lib.notify({ id = 'inventory_player_access', type = 'error', description = locale('inventory_player_access') })
     end
 
-    local left, right, accessError
+    local left, right, accessError, backpack
 
     if inv == 'player' and data ~= cache.serverId then
         local targetId, targetPed
@@ -235,7 +235,7 @@ function client.openInventory(inv, data)
             end
         end
 
-        left, right, accessError = lib.callback.await('ox_inventory:openInventory', false, inv, data)
+        left, right, accessError, backpack = lib.callback.await('ox_inventory:openInventory', false, inv, data)
     end
 
     if accessError then
@@ -279,7 +279,8 @@ function client.openInventory(inv, data)
         action = 'setupInventory',
         data = {
             leftInventory = left,
-            rightInventory = currentInventory
+            rightInventory = currentInventory,
+            backpackInventory = backpack
         }
     })
 
@@ -333,13 +334,14 @@ RegisterNetEvent('ox_inventory:forceOpenInventory', function(left, right)
 	left.items = PlayerData.inventory
 	left.groups = PlayerData.groups
 
-	SendNUIMessage({
-		action = 'setupInventory',
-		data = {
-			leftInventory = left,
-			rightInventory = currentInventory
-		}
-	})
+        SendNUIMessage({
+                action = 'setupInventory',
+                data = {
+                        leftInventory = left,
+                        rightInventory = currentInventory,
+                        backpackInventory = backpack
+                }
+        })
 end)
 
 local Animations = lib.load('data.animations')
@@ -1592,13 +1594,14 @@ RegisterNetEvent('ox_inventory:viewInventory', function(left, right)
 	left.items = PlayerData.inventory
 	left.groups = PlayerData.groups
 
-	SendNUIMessage({
-		action = 'setupInventory',
-		data = {
-			leftInventory = left,
-			rightInventory = currentInventory
-		}
-	})
+        SendNUIMessage({
+                action = 'setupInventory',
+                data = {
+                        leftInventory = left,
+                        rightInventory = currentInventory,
+                        backpackInventory = backpack
+                }
+        })
 end)
 
 RegisterNUICallback('uiLoaded', function(_, cb)

--- a/ox_inventory-custom/locales/en.json
+++ b/ox_inventory-custom/locales/en.json
@@ -54,6 +54,7 @@
   "cannot_carry_other": "Target inventory can not hold that much",
   "cannot_carry_limit": "You cannot carry more than %s %s",
   "cannot_carry_limit_other": "Target cannot carry more than %s %s",
+  "backpack_not_empty": "You can't remove your backpack while it contains items",
   "items_confiscated": "Your items have been confiscated",
   "items_returned": "Your items have been returned",
   "item_unauthorised": "You are not authorised to purchase this item",

--- a/ox_inventory-custom/locales/pl.json
+++ b/ox_inventory-custom/locales/pl.json
@@ -54,6 +54,7 @@
   "cannot_carry_other": "Docelowy ekwipunek nie może tyle unieść",
   "cannot_carry_limit": "Nie możesz unieść więcej niż %s %s",
   "cannot_carry_limit_other": "Docelowy ekwipunek nie może unieść %s %s",
+  "backpack_not_empty": "❌ Nie możesz zdjąć plecaka, gdy są w nim przedmioty.",
   "items_confiscated": "Twoje przedmioty zostały skonfiskowane",
   "items_returned": "Twoje przedmioty zostały zwrócone",
   "item_unauthorised": "Nie posiadasz autoryzacji do zakupu tego przedmiotu",

--- a/ox_inventory-custom/modules/inventory/server.lua
+++ b/ox_inventory-custom/modules/inventory/server.lua
@@ -1765,6 +1765,15 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
             data.count = fromData.count
         end
 
+        -- Prevent unequipping backpack with items inside
+        if data.fromType == 'player' and data.fromSlot == 6 and fromData.metadata?.container then
+            local bagInv = Inventory.GetContainerFromSlot(fromInventory, data.fromSlot)
+            if bagInv and next(bagInv.items) then
+                TriggerClientEvent('ox_lib:notify', source, { type = 'error', description = locale('backpack_not_empty') })
+                return false
+            end
+        end
+
         if data.toType == 'newdrop' then
             return dropItem(source, playerInventory, fromData, data)
         end

--- a/ox_inventory-custom/modules/items/containers.lua
+++ b/ox_inventory-custom/modules/items/containers.lua
@@ -58,9 +58,35 @@ setContainerProperties('paperbag', {
 })
 
 setContainerProperties('pizzabox', {
-	slots = 5,
-	maxWeight = 1000,
-	whitelist = { 'pizza' }
+        slots = 5,
+        maxWeight = 1000,
+        whitelist = { 'pizza' }
+})
+
+-- Backpack containers
+setContainerProperties('backpack1', {
+       slots = shared.playerslots - 9,
+       maxWeight = 20000
+})
+
+setContainerProperties('backpack2', {
+       slots = shared.playerslots - 9,
+       maxWeight = 40000
+})
+
+setContainerProperties('backpack3', {
+       slots = shared.playerslots - 9,
+       maxWeight = 60000
+})
+
+setContainerProperties('backpack4', {
+       slots = shared.playerslots - 9,
+       maxWeight = 80000
+})
+
+setContainerProperties('backpack5', {
+       slots = shared.playerslots - 9,
+       maxWeight = 100000
 })
 
 return containers

--- a/ox_inventory-custom/server.lua
+++ b/ox_inventory-custom/server.lua
@@ -198,24 +198,44 @@ local function openInventory(source, invType, data, ignoreSecurityChecks)
 		left:openInventory(left)
 	end
 
-	return {
-		id = left.id,
-		label = left.label,
-		type = left.type,
-		slots = left.slots,
-		weight = left.weight,
-		maxWeight = left.maxWeight
-	}, right and {
-		id = right.id,
-		label = right.player and '' or right.label,
-		type = right.player and 'otherplayer' or right.type,
-		slots = right.slots,
-		weight = right.weight,
-		maxWeight = right.maxWeight,
-		items = right.items,
-		coords = closestCoords or right.coords,
-		distance = right.distance
-	}
+        local backpack
+
+        if invType == 'player' then
+                local bag = left.items[6]
+                if bag and bag.metadata and bag.metadata.container then
+                        local bagInv = Inventory.GetContainerFromSlot(left, 6)
+                        if bagInv then
+                                backpack = {
+                                        id = bagInv.id,
+                                        label = bag.label,
+                                        type = bagInv.type,
+                                        slots = bagInv.slots,
+                                        weight = bagInv.weight,
+                                        maxWeight = bagInv.maxWeight,
+                                        items = bagInv.items
+                                }
+                        end
+                end
+        end
+
+        return {
+                id = left.id,
+                label = left.label,
+                type = left.type,
+                slots = left.slots,
+                weight = left.weight,
+                maxWeight = left.maxWeight
+        }, right and {
+                id = right.id,
+                label = right.player and '' or right.label,
+                type = right.player and 'otherplayer' or right.type,
+                slots = right.slots,
+                weight = right.weight,
+                maxWeight = right.maxWeight,
+                items = right.items,
+                coords = closestCoords or right.coords,
+                distance = right.distance
+        }, nil, backpack
 end
 
 ---@param source number

--- a/ox_inventory-custom/web/src/components/inventory/BackpackInventory.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/BackpackInventory.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import InventoryGrid from './InventoryGrid';
+import { useAppSelector } from '../../store';
+import { selectBackpackInventory } from '../../store/inventory';
+
+const BackpackInventory: React.FC = () => {
+  const backpack = useAppSelector(selectBackpackInventory);
+  const [collapsed, setCollapsed] = useState(false);
+  if (!backpack.id) return null;
+
+  return (
+    <div className="backpack-inventory">
+      <h2 className="pockets-title">Backpack ({backpack.label})</h2>
+      <InventoryGrid
+        inventory={backpack}
+        showSlotNumbers={false}
+        collapsible
+        collapsed={collapsed}
+        onToggleCollapse={() => setCollapsed(!collapsed)}
+      />
+    </div>
+  );
+};
+
+export default BackpackInventory;

--- a/ox_inventory-custom/web/src/components/inventory/index.tsx
+++ b/ox_inventory-custom/web/src/components/inventory/index.tsx
@@ -8,6 +8,7 @@ import type { Inventory as InventoryProps } from '../../typings';
 import EquipmentInventory from './EquipmentInventory';
 import GroundInventory from './GroundInventory';
 import LeftInventory from './LeftInventory';
+import BackpackInventory from './BackpackInventory';
 import InventoryTabs from './InventoryTabs';
 import Tooltip from '../utils/Tooltip';
 import { closeTooltip } from '../../store/tooltip';
@@ -35,6 +36,7 @@ const Inventory: React.FC = () => {
   useNuiEvent<{
     leftInventory?: InventoryProps;
     rightInventory?: InventoryProps;
+    backpackInventory?: InventoryProps;
   }>('setupInventory', (data) => {
     dispatch(setupInventory(data));
     !inventoryVisible && setInventoryVisible(true);
@@ -71,6 +73,7 @@ const Inventory: React.FC = () => {
             {rightInventory.type === 'shop' ? <ShopInventory /> : <GroundInventory />}
           </Fade>
           <LeftInventory />
+          <BackpackInventory />
           <Tooltip />
           <InventoryContext />
         </div>

--- a/ox_inventory-custom/web/src/index.scss
+++ b/ox_inventory-custom/web/src/index.scss
@@ -349,6 +349,19 @@ button:active {
   padding: 10px;
 }
 
+.backpack-inventory {
+  position: absolute;
+  right: 10%;
+  top: 75%;
+  transform: translateY(-50%) perspective(1000px) rotateY(-10deg);
+  transform-origin: right center;
+  background: rgba(24, 24, 24, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 0 24px rgba(0, 0, 0, 0.6);
+  border-radius: 18px;
+  padding: 10px;
+}
+
 .ground-inventory {
   position: absolute;
   left: 4%;
@@ -1057,6 +1070,21 @@ button:active {
   }
 
   .left-inventory {
+    right: 10%;
+    transform: translateY(-50%) perspective(1000px) rotateY(-10deg);
+    transform-origin: right center;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.3);
+    backdrop-filter: blur(6px);
+    box-shadow: 0 0 20px rgba(0, 0, 0, 0.4);
+
+    .inventory-grid-container::-webkit-scrollbar {
+      width: 8px;
+    }
+  }
+
+  .backpack-inventory {
     right: 10%;
     transform: translateY(-50%) perspective(1000px) rotateY(-10deg);
     transform-origin: right center;

--- a/ox_inventory-custom/web/src/reducers/refreshSlots.ts
+++ b/ox_inventory-custom/web/src/reducers/refreshSlots.ts
@@ -60,6 +60,8 @@ export const refreshSlotsReducer: CaseReducer<State, PayloadAction<Payload>> = (
         ? 'leftInventory'
         : inventoryId === state.rightInventory.id
         ? 'rightInventory'
+        : inventoryId === state.backpackInventory.id
+        ? 'backpackInventory'
         : null;
 
     if (!inv) return;
@@ -76,6 +78,8 @@ export const refreshSlotsReducer: CaseReducer<State, PayloadAction<Payload>> = (
         ? 'leftInventory'
         : inventoryId === state.rightInventory.id
         ? 'rightInventory'
+        : inventoryId === state.backpackInventory.id
+        ? 'backpackInventory'
         : null;
 
     if (!inv) return;
@@ -86,6 +90,7 @@ export const refreshSlotsReducer: CaseReducer<State, PayloadAction<Payload>> = (
       payload: {
         leftInventory: inv === 'leftInventory' ? state[inv] : undefined,
         rightInventory: inv === 'rightInventory' ? state[inv] : undefined,
+        backpackInventory: inv === 'backpackInventory' ? state[inv] : undefined,
       },
     });
   }

--- a/ox_inventory-custom/web/src/reducers/setupInventory.ts
+++ b/ox_inventory-custom/web/src/reducers/setupInventory.ts
@@ -8,9 +8,10 @@ export const setupInventoryReducer: CaseReducer<
   PayloadAction<{
     leftInventory?: Inventory;
     rightInventory?: Inventory;
+    backpackInventory?: Inventory;
   }>
 > = (state, action) => {
-  const { leftInventory, rightInventory } = action.payload;
+  const { leftInventory, rightInventory, backpackInventory } = action.payload;
   const curTime = Math.floor(Date.now() / 1000);
 
   if (leftInventory)
@@ -37,6 +38,25 @@ export const setupInventoryReducer: CaseReducer<
       ...rightInventory,
       items: Array.from(Array(rightInventory.slots), (_, index) => {
         const item = Object.values(rightInventory.items).find((item) => item?.slot === index + 1) || {
+          slot: index + 1,
+        };
+
+        if (!item.name) return item;
+
+        if (typeof Items[item.name] === 'undefined') {
+          getItemData(item.name);
+        }
+
+        item.durability = itemDurability(item.metadata, curTime);
+        return item;
+      }),
+    };
+
+  if (backpackInventory)
+    state.backpackInventory = {
+      ...backpackInventory,
+      items: Array.from(Array(backpackInventory.slots), (_, index) => {
+        const item = Object.values(backpackInventory.items).find((item) => item?.slot === index + 1) || {
           slot: index + 1,
         };
 

--- a/ox_inventory-custom/web/src/store/inventory.ts
+++ b/ox_inventory-custom/web/src/store/inventory.ts
@@ -24,6 +24,13 @@ const initialState: State = {
     maxWeight: 0,
     items: [],
   },
+  backpackInventory: {
+    id: '',
+    type: '',
+    slots: 0,
+    maxWeight: 0,
+    items: [],
+  },
   additionalMetadata: new Array(),
   itemAmount: 0,
   shiftPressed: false,
@@ -56,7 +63,11 @@ export const inventorySlice = createSlice({
       state.shiftPressed = action.payload;
     },
     setContainerWeight: (state, action: PayloadAction<number>) => {
-      const container = state.leftInventory.items.find((item) => item.metadata?.container === state.rightInventory.id);
+      let container = state.leftInventory.items.find((item) => item.metadata?.container === state.rightInventory.id);
+
+      if (!container && state.backpackInventory.id) {
+        container = state.leftInventory.items.find((item) => item.metadata?.container === state.backpackInventory.id);
+      }
 
       if (!container) return;
 
@@ -105,6 +116,7 @@ export const selectEquipmentInventory = (state: RootState) => ({
   ...state.inventory.leftInventory,
   items: state.inventory.leftInventory.items.slice(0, 9),
 });
+export const selectBackpackInventory = (state: RootState) => state.inventory.backpackInventory;
 export const selectRightInventory = (state: RootState) => state.inventory.rightInventory;
 export const selectItemAmount = (state: RootState) => state.inventory.itemAmount;
 export const selectIsBusy = (state: RootState) => state.inventory.isBusy;

--- a/ox_inventory-custom/web/src/typings/state.ts
+++ b/ox_inventory-custom/web/src/typings/state.ts
@@ -4,6 +4,7 @@ import { Slot } from './slot';
 export type State = {
   leftInventory: Inventory;
   rightInventory: Inventory;
+  backpackInventory: Inventory;
   itemAmount: number;
   shiftPressed: boolean;
   isBusy: boolean;


### PR DESCRIPTION
## Summary
- register backpack containers
- add locale for blocking backpack removal
- prevent unequipping backpack when items remain
- include backpack inventory when opening player inventory
- expose backpack inventory in React store
- render backpack menu below pockets

## Testing
- `npm run build` *(fails: Cannot find module '@reduxjs/toolkit')*

------
https://chatgpt.com/codex/tasks/task_e_6867269956bc83259538c24e548a890a